### PR TITLE
Code tab points to mirage github org page

### DIFF
--- a/src/template.ml
+++ b/src/template.ml
@@ -7,7 +7,7 @@ let bar cur =
     "/","Home";
     "/blog/","Blog";
     "/wiki/","Wiki"; 
-    "http://github.com/avsm/mirage", "Code";
+    "http://github.com/mirage/", "Code";
     "/about/","About"
   ] in
   let one (href, title) =


### PR DESCRIPTION
I noticed that the Code tab on the main mirage page still points to Anil's github account. This patch makes it point to github.com/mirage instead. I noticed that there are a lot of other links pointing to github.com/avsm, but this one seemed the most important to change.
