### PR TITLE
Added missing dependency to mirage-net

### DIFF
--- a/src/www.conf
+++ b/src/www.conf
@@ -16,4 +16,4 @@ main-http: Dispatch.t
 
 # Dependencies
 depends: cohttp.mirage, uri, re, cow.syntax, cow, ulex
-packages: cohttp, cow, mirage-fs
+packages: cohttp, cow, mirage-fs, mirage-net


### PR DESCRIPTION
On my setup (4.01.0dev+mirage-xen), mirage-net was necessary to build mirage-www, and it was not installed by mirari because not specified in the dependencies field.

This patch fixed things for me.
