### PR TITLE
Use regular expressions for expanding templates

### DIFF
--- a/src/template.ml
+++ b/src/template.ml
@@ -21,13 +21,28 @@ let bar cur =
       >> in
   <:xml< <ul>$list:List.map one bars$</ul> >>
 
-let replace (templates: (string * Xml.t) list) (xml:Xml.t) =
+let replace (templates: (Re_str.regexp * Xml.t) list) (xml:Xml.t) =
   let rec aux = function
     | `El (t, xs)    -> [`El (t, List.flatten (List.map aux xs))]
-    | `Data str as x ->
-      try List.assoc str templates
-      with Not_found -> [x] in
+    | `Data _ as x ->
+      (* Replace one of the templates: *)
+      let rec one (regexp, xml) x : Xml.t = match x with
+        | `Data str ->
+          let bits = Re_str.full_split regexp str in
+          List.flatten (List.map (function
+          | Re_str.Text x -> [ `Data x ]
+          | Re_str.Delim _ -> xml
+          ) bits)
+        | `El (_, _) as x -> [ x ] in
+      List.fold_left (fun acc transform ->
+        List.flatten (List.map (one transform) acc)
+      ) [ x ] templates in
   List.flatten (List.map aux xml)
+
+let _title         = Re_str.regexp_string "$TITLE$"
+let _bar           = Re_str.regexp_string "$BAR$"
+let _extra_headers = Re_str.regexp_string "$EXTRA_HEADER$"
+let _contents      = Re_str.regexp_string "$CONTENT$"
 
 let t ?extra_header page title content =
   lwt tmpl = OS.Devices.find_kv_ro "templates" >>=
@@ -38,10 +53,10 @@ let t ?extra_header page title content =
   match_lwt tmpl#read "/main.html" with
     | Some main_html ->
       let templates = [
-        "$TITLE$"       , <:xml<$str:title$>>;
-        "$BAR$"         , <:xml<$bar page$>>;
-        "$EXTRA_HEADER$", <:xml<$opt:extra_header$>>;
-        "$CONTENT$"     , <:xml<$content$>>;
+        _title         , <:xml<$str:title$>>;
+        _bar           , <:xml<$bar page$>>;
+        _extra_headers , <:xml<$opt:extra_header$>>;
+        _contents      , <:xml<$content$>>;
       ] in
       Util.string_of_stream main_html >|= Html.of_string >|= replace templates
     | None ->


### PR DESCRIPTION
Previously the `Data elements had leading and trailing whitespace
and additional text ("openmirage :: $TITLE$") which means we need
something stronger than List.assoc.
