### PR TITLE
Atom feed should have absolute uris

### DIFF
--- a/src/blog.ml
+++ b/src/blog.ml
@@ -238,7 +238,7 @@ let permalink_exists x = List.exists (fun e -> e.permalink = x) entries
 let atom_entry_of_ent filefn e =
   let links = [
     Atom.mk_link ~rel:`alternate ~typ:"text/html"
-      (Uri.of_string (permalink e)) 
+      (Config.mk_uri (permalink e)) 
   ] in
   let meta = {
     Atom.id      = permalink e;


### PR DESCRIPTION
I didn't actually check out this code to test it (I don't have a working vm with Mirage right now) but I'm a lurker and the relative links in the Atom feed were starting to bug me. I'm open to other ways to accomplish this if there's a better one.
