### PR TITLE
Support reading static data from block devices

### DIFF
--- a/src/dispatch.ml
+++ b/src/dispatch.ml
@@ -45,23 +45,111 @@ let rec remove_empty_tail = function
   | [] | [""] -> []
   | hd::tl -> hd :: remove_empty_tail tl
 
+module Tar_IO = Tar.Archive(struct
+  type 'a t = 'a Lwt.t
+  let ( >>= ) = Lwt.bind
+  let return = Lwt.return
+end)
+
+module StringMap = Map.Make(struct type t = string let compare (a: string) (b: string) = compare a b end)
+
+(* Create a kv_ro disk device from a block device with tar-format data *)
+let make_kv_ro_from_tar blkif =
+  (* Compare filenames without a leading / *)
+  let trim_slash = function
+    | "" -> ""
+    | x when x.[0] = '/' -> String.sub x 1 (String.length x - 1)
+    | x -> x in
+  (* Build an in-memory index of the data *)
+  lwt map = Tar_IO.fold (fun map tar data_offset ->
+    let filename = trim_slash tar.Tar.Header.file_name in
+    let map = StringMap.add filename (tar, data_offset) map in
+    Printf.printf "Adding [%s] (size %Ld)\n%!" filename tar.Tar.Header.file_size;
+    return map
+  ) StringMap.empty (fun x -> Lwt_stream.next (blkif#read_512 x 1L)) in
+  Printf.printf "Indexed %d files\n%!" (StringMap.cardinal map);
+  return (object
+    method read name =
+      let name = trim_slash name in
+      if not(StringMap.mem name map)
+      then return None
+      else
+        let tar, from = StringMap.find name map in
+        let sectors = Tar.Header.to_sectors tar in
+        let s = blkif#read_512 from sectors in
+        (* the stream will be zero-padded, we need to clip the end off *)
+        let remaining = ref tar.Tar.Header.file_size in
+        return (Some (Lwt_stream.from (fun () ->
+          if !remaining = 0L
+          then return None
+          else match_lwt Lwt_stream.get s with
+            | None -> return None (* truncated *)
+            | Some chunk ->
+              let len_64 = Int64.of_int (Cstruct.len chunk) in
+              if len_64 >= !remaining then begin
+                remaining := Int64.sub !remaining len_64;
+                return (Some chunk)
+              end else begin
+                let chunk' = Cstruct.sub chunk 0 (Int64.to_int !remaining) in
+                remaining := 0L;
+                return (Some chunk')
+              end
+        )))
+  end)
+
+let disk =
+  lwt () = Blkfront.register () in
+  let blkif, u = Lwt.task () in
+  let _ = OS.Devices.listen (fun id ->
+    OS.Devices.find_blkif id >>= function
+    | None -> return ()
+    | Some blkif ->
+      Printf.printf "Block device %s data available\n%!" id;
+      Lwt.wakeup u blkif; return ()
+  ) in
+  lwt blkif = blkif in
+  make_kv_ro_from_tar blkif
+
+let static =
+  eprintf "finding the static kv_ro block device\n";
+  let t, u = Lwt.task () in
+  let _ = OS.Devices.find_kv_ro "static" >>= function
+    | None -> return ()
+    | Some x ->
+      Printf.printf "KV_RO data available\n%!";
+      Lwt.wakeup u x; return () in
+  t
+
+class type reader = object
+  method read: string -> Cstruct.t Lwt_stream.t option Lwt.t
+end
+
+let resources = [
+  (disk :> reader Lwt.t); 
+  (static :> reader Lwt.t);
+]
+
 (* main callback function *)
 let t conn_id ?body req =
   let path = Uri.path (CL.Request.uri req) in
   let path_elem =
     remove_empty_tail (Re_str.split_delim (Re_str.regexp_string "/") path)
   in
-  lwt static =
-    eprintf "finding the static kv_ro block device\n";
-    OS.Devices.find_kv_ro "static" >>=
-    function
-    | None   -> Printf.printf "fatal error, static kv_ro not found\n%!"; exit 1
-    | Some x -> return x in
-
-  (* determine if it is static or dynamic content *)
-  match_lwt static#read path with
-  |Some body ->
-     lwt body = Util.string_of_stream body in
-     CL.Server.respond_string ~status:`OK ~body ()
-  |None ->
-     Resp.dispatch req path_elem
+  (* Look through the threads in order, if one is ready then attempt
+     to use it, otherwise fall through to the next *)
+  let rec lookup = function
+  | [] ->
+    Resp.dispatch req path_elem
+  | t :: ts ->
+    begin match Lwt.poll t with
+    | None -> lookup ts
+    | Some store ->
+      lwt contents = store#read path in
+      begin match contents with
+      | None -> lookup ts
+      | Some body ->
+        lwt body = Util.string_of_stream body in
+        CL.Server.respond_string ~status:`OK ~body ()
+      end
+    end in
+  lookup resources

--- a/src/www.conf
+++ b/src/www.conf
@@ -16,5 +16,5 @@ fs-templates: ../tmpl
 main-http: Dispatch.t
 
 # Dependencies
-depends: cohttp.mirage, uri, re, cow.syntax, cow, ulex, uri, xmlm
-packages: cohttp, cow, mirage-fs, mirage-net, uri, xmlm
+depends: cohttp.mirage, uri, re, cow.syntax, cow, ulex, uri, xmlm, tar, xenblock.front
+packages: cohttp, cow, mirage-fs, mirage-net, uri, xmlm, tar-format


### PR DESCRIPTION
The webserver now has a list of 'resources' which are
threads which, if they return, are objects supporting
a 'read' method. The resources are interrogated in order
when looking up URI paths.

By default we have a 'disk' resource thread which
unblocks if a block frontend is connected. Next we have
a 'static' resource which represents the kv_ro built-in
crunched filesystem.

The disk data is assumed to be in a simple tar format.
You can create the disk by:

 cd files
 tar -cf $HOME/www.tar .
 sudo losetup /dev/loop0 $HOME/www.tar

and then adding '/dev/loop0' to the VM via an xl config
file entry:

 disk=[ 'phy:/dev/loop0,xvda,w' ]

Signed-off-by: David Scott dave.scott@eu.citrix.com

NB this won't work without
- mirage/ocaml-xen-block-driver#4
- mirage/mirage-platform#51
- djs55/ocaml-tar#3
