### PR TITLE
update mailing list info

### DIFF
--- a/tmpl/about-r.md
+++ b/tmpl/about-r.md
@@ -1,6 +1,6 @@
 !!The Channels
 
-* *E-mail*: developer mailing list at [lists.cam.ac.uk](https://lists.cam.ac.uk/mailman/listinfo/cl-mirage) and [archive](https://lists.cam.ac.uk/pipermail/cl-mirage/)
+* *E-mail*: developer mailing list at [http://www.xenproject.org/help/mailing-list.html](http://lists.xenproject.org/cgi-bin/mailman/listinfo/mirageos-devel) and [archive](http://lists.xenproject.org/archives/html/mirageos-devel/)
 * *IRC*: `#mirage` on `irc.freenode.org`
 * *Twitter*: [openmirage](http://twitter.com/openmirage)
 * *Meetings*: [Kingston Arms](http://www.kingston-arms.co.uk/)


### PR DESCRIPTION
To be merged when ready.

List has moved to XenProject and
archives will be moved in due course.
