### PR TITLE
Support a choice of either Crunch or FAT

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -1,15 +1,41 @@
 open Mirage
 
-let fs =
-  Driver.KV_RO {
+(* If the Unix `MODE` is set, the choice of configuration changes:
+   MODE=crunch (or nothing): use static filesystem via crunch
+   MODE=fat: use FAT and block device (run ./make-fat-images.sh)
+ *)
+let static_fs =
+    Driver.KV_RO {
     KV_RO.name = "files";
     dirname    = "../files";
   }
 
-let tmpl =
+let static_tmpl =
   Driver.KV_RO {
     KV_RO.name = "tmpl";
     dirname    = "../tmpl";
+  }
+
+let fat_fs =
+  let block = {
+    Block.name = "fs_block";
+    filename   = "files.img";
+    read_only  = true;
+  } in
+  Driver.Fat_KV_RO {
+    Fat_KV_RO.name = "files";
+    block;
+  }
+
+let fat_tmpl =
+  let block = {
+    Block.name = "tmpl_block";
+    filename   = "tmpl.img";
+    read_only  = true;
+  } in
+  Driver.Fat_KV_RO {
+    Fat_KV_RO.name = "tmpl";
+    block;
   }
 
 let http =
@@ -19,7 +45,19 @@ let http =
     ip         = IP.local Network.Tap0;
   }
 
+let mode =
+  try begin
+     match String.lowercase (Unix.getenv "MODE") with
+     | "fat" -> `Fat
+     | _ -> `Crunch
+  end with Not_found -> `Crunch
+
+let drivers =
+  match mode with
+  | `Crunch -> [Driver.console; static_fs; static_tmpl; http]
+  | `Fat -> [Driver.console; fat_fs; fat_tmpl; http]
+
 let () =
   Job.register [
-    "Dispatch.Main", [Driver.console; fs; tmpl; http]
+    "Dispatch.Main", drivers
   ]

--- a/src/make-fat-images.sh
+++ b/src/make-fat-images.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+echo This uses the 'fat' command-line tool to build the FAT
+echo filesystem images for the static files and templates.
+
+FAT=$(which fat)
+if [ ! -x "${FAT}" ]; then
+  echo I couldn\'t find the 'fat' command-line tool.
+  echo Try running 'opam install fat-filesystem'
+  exit 1
+fi
+rm -f files.img tmpl.img
+${FAT} create files.img
+${FAT} create tmpl.img
+cd ../files
+${FAT} add ../src/files.img *
+cd ../tmpl
+${FAT} add ../src/tmpl.img *
+echo Created 'files.img'
+echo Created 'tmpl.img'
+


### PR DESCRIPTION
If the Unix `MODE` is set, the choice of configuration changes:
- `MODE=crunch` (or nothing): use static filesystem via crunch
- `MODE=fat`: use FAT and block device (run ./make-fat-images.sh)

This requires mirage/mirage#160 to be merged before it'll build. 
