### PR TITLE
update front page blurb

### DIFF
--- a/tmpl/intro-1.md
+++ b/tmpl/intro-1.md
@@ -1,4 +1,4 @@
-Mirage constructs [unikernels](http://queue.acm.org/detail.cfm?id=2566628)
+Mirage OS is a library operating system that constructs [unikernels](http://queue.acm.org/detail.cfm?id=2566628)
 for secure, high-performance network applications across a variety
 of cloud computing and mobile platforms.  Code can be developed on a normal OS
 such as Linux or MacOS X, and then compiled into a fully-standalone,

--- a/tmpl/intro-3.md
+++ b/tmpl/intro-3.md
@@ -1,4 +1,4 @@
 Mirage 1.0 was [released in December 2013](http://openmirage.org/blog/announcing-mirage10),
 and the infrastructure you see here is [self-hosted](https://github.com/mirage/mirage-www).
 Check out the [documentation](/wiki), compile your [hello world
-microkernel](/wiki/hello-world), get started with the [public cloud](/wiki/xen-boot), or watch the [talks](/wiki/talks).
+unikernel](/wiki/hello-world), get started with the [public cloud](/wiki/xen-boot), or watch the [talks](/wiki/talks).


### PR DESCRIPTION
Expand first sentence to be clear between Mirage OS and its output.
Fix one mention of microkernel to unikernel.
