### PR TITLE
Increase dom0 memory to 256M

### DIFF
--- a/tmpl/wiki/xen-on-cubieboard2.md
+++ b/tmpl/wiki/xen-on-cubieboard2.md
@@ -105,52 +105,22 @@ Configure and build U-Boot using the ARM toolchain:
 
 ## U-Boot configuration
 
-Create a directory for the boot commands (e.g. "boot"). Create
-"boot/[boot.cmd](https://github.com/mirage/xen-arm-builder/blob/master/boot/boot-cubieboard2.cmd)" with:
+Create a directory for the boot commands (e.g. `boot`). Create
+`boot/boot.cmd` whose content is the same as
+[boot-cubieboard2.cmd](https://github.com/mirage/xen-arm-builder/blob/master/boot/boot-cubieboard2.cmd)
+for the Cubieboard2 or
+[boot-cubietruck.cmd](https://github.com/mirage/xen-arm-builder/blob/master/boot/boot-cubietruck.cmd)
+for the Cubietruck.
 
-    # SUNXI Xen Boot Script
-    
-    # Addresses suitable for 1GB system, adjust as appropriate for a 2GB system.
-    # Top of RAM:         0x80000000
-    # Xen relocate addr   0x7fe00000
-    setenv kernel_addr_r  0x7f600000 # 8M
-    setenv ramdisk_addr_r 0x7ee00000 # 8M
-    setenv fdt_addr       0x7ec00000 # 2M
-    setenv xen_addr_r     0x7ea00000 # 2M
-    
-    setenv fdt_high      0xffffffff # Load fdt in place instead of relocating
-    
-    # Load xen/xen to ${xen_addr_r}.
-    fatload mmc 0 ${xen_addr_r} /xen
-    setenv bootargs "console=dtuart dtuart=/soc@01c00000/serial@01c28000 dom0_mem=256M"
-    
-    # Load appropriate .dtb file to ${fdt_addr}
-    fatload mmc 0 ${fdt_addr} /sun7i-a20-cubieboard2.dtb
-    fdt addr ${fdt_addr} 0x40000
-    fdt resize
-    fdt chosen
-    fdt set /chosen \#address-cells <1>
-    fdt set /chosen \#size-cells <1>
-    
-    # Load Linux arch/arm/boot/zImage to ${kernel_addr_r}
-    fatload mmc 0 ${kernel_addr_r} /vmlinuz
-    
-    fdt mknod /chosen module@0
-    fdt set /chosen/module@0 compatible "xen,linux-zimage" "xen,multiboot-module"
-    fdt set /chosen/module@0 reg <${kernel_addr_r} 0x${filesize} >
-    fdt set /chosen/module@0 bootargs "console=hvc0 ro root=/dev/mmcblk0p2 rootwait init=/bin/bash clk_ignore_unused"
-    
-    bootz ${xen_addr_r} - ${fdt_addr}
-
-The above is the template from the wiki, but configured to:
+The above is configured to:
 
 - Load Xen, the FDT and Linux from `mmcblk0p1`
-- Use mmcblk0p2 as Linux's root FS
+- Use `mmcblk0p2` as Linux's root FS
 - Wait for the device (`rootwait`)
-- Run /bin/bash as init.
+- Run `/bin/bash` as init.
 
 More information on
-[the format of this file](http://www.denx.de/wiki/view/DULG/UBoot)
+[the format of `boot.cmd`](http://www.denx.de/wiki/view/DULG/UBoot)
 is available on the [denx site](http://www.denx.de/wiki/view/DULG/Manual).
 
 Create a `Makefile` to compile it using


### PR DESCRIPTION
Without this `apt-get install openssh-server` is excruciatingly slow.
