### PR TITLE
fix port configuration

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -57,7 +57,7 @@ let server =
   conduit_direct (stack default_console)
 
 let http_srv =
-  let mode = `TCP (`Port 80) in
+  let mode = `TCP (`Port port) in
   http_server mode server
 
 let main =


### PR DESCRIPTION
config.ml takes PORT from the environment, but did not actually apply it to the TCP listener
