### PR TITLE
Add PORT to Sockets instructions

### DIFF
--- a/tmpl/wiki/mirage-www.md
+++ b/tmpl/wiki/mirage-www.md
@@ -48,7 +48,7 @@ using your favourite editor.
 
 ```
 $ cd src
-$ env NET=socket FS=crunch mirage configure --unix
+$ env NET=socket PORT=8080 FS=crunch mirage configure --unix
 $ make depend
 $ make
 $ make run


### PR DESCRIPTION
fixes #299

> Unix doesn't allow non-root processes to listen on ports < 1024