### PR TITLE
Redirect "weekly" urls to "Weekly calls and release notes"

### DIFF
--- a/src/dispatch.ml
+++ b/src/dispatch.ml
@@ -77,7 +77,7 @@ module Main
         | "links"    :: tl -> return (links_dispatch tl)
         | "updates"  :: tl -> return (`Page (updates_dispatch tl))
 
-        | "wiki" :: "weekly" :: tl -> return (`Redirect "../wiki#Weeklycallsandreleasenotes")
+        | ("wiki" | "docs") :: "weekly" :: tl -> return (`Redirect "../wiki#Weeklycallsandreleasenotes")
         | "docs" :: tl
         | "wiki" :: tl -> return (`Page (wiki_dispatch tl))
 

--- a/src/dispatch.ml
+++ b/src/dispatch.ml
@@ -77,6 +77,7 @@ module Main
         | "links"    :: tl -> return (links_dispatch tl)
         | "updates"  :: tl -> return (`Page (updates_dispatch tl))
 
+        | "wiki" :: "weekly" :: tl -> return (`Redirect "../wiki#Weeklycallsandreleasenotes")
         | "docs" :: tl
         | "wiki" :: tl -> return (`Page (wiki_dispatch tl))
 


### PR DESCRIPTION
Redirect the following to the "Weekly calls and release notes" section on the docs index page:
openmirage.org/wiki/weekly
openmirage.org/docs/weekly

Fixes #269 