### PR TITLE
Store GC stats in RRDs, render on client-side with C3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@
 /src/make-fat1-image.sh
 /src/make-fat2-image.sh
 
+files/js/stats
+
 .*.swp

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MIRAGE ?= mirage
 MODE   ?= unix
 FS     ?= fat
 NET    ?= direct
-IPADDR ?= static
+IPADDR ?= dhcp
 
 FLAGS  ?=
 
@@ -37,9 +37,11 @@ configure:
 	$(MIRAGE) configure src/config.ml $(FLAGS) --$(MODE)
 
 depend:
+	cd stats && make depend
 	cd src && make depend
 
 build:
+	cd stats && make all
 	cd src && make build
 
 run:
@@ -47,4 +49,5 @@ run:
 
 clean:
 	cd src && make clean
+	cd stats && make clean
 	$(RM) log src/mir-www src/*.img src/make-fat*.sh

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MIRAGE ?= mirage
 MODE   ?= unix
 FS     ?= fat
 NET    ?= direct
-IPADDR ?= dhcp
+IPADDR ?= static
 
 FLAGS  ?=
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -111,7 +111,7 @@ let stack = match deploy with
     | `Socket, _     -> socket_stackv4 cons0 [Ipaddr.V4.any]
 
 let libraries = [ "cow.syntax"; "cowabloga"; "rrd" ]
-let packages  = [ "cow"; "cowabloga"; "xapi-rrd" ]
+let packages  = [ "cow"; "cowabloga"; "xapi-rrd"; "c3"; "js_of_ocaml" ]
 
 let sp = Printf.sprintf
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -110,8 +110,8 @@ let stack = match deploy with
     | `Direct, true  -> direct_stackv4_with_dhcp cons0 tap0
     | `Socket, _     -> socket_stackv4 cons0 [Ipaddr.V4.any]
 
-let libraries = [ "cow.syntax"; "cowabloga" ]
-let packages  = [ "cow"; "cowabloga" ]
+let libraries = [ "cow.syntax"; "cowabloga"; "rrd" ]
+let packages  = [ "cow"; "cowabloga"; "xapi-rrd" ]
 
 let sp = Printf.sprintf
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -124,7 +124,7 @@ let main = sp "Make(%s)" config
 
 let http =
   foreign ~libraries ~packages ("Dispatch." ^ main)
-    (console @-> kv_ro @-> kv_ro @-> http @-> job)
+    (console @-> kv_ro @-> kv_ro @-> http @-> clock @-> job)
 
 let https =
   let libraries = "tls" :: "tls.mirage" :: "mirage-http" :: libraries in
@@ -143,7 +143,8 @@ let () =
   register ?tracing image [ match tls with
       | false ->
         let server = http_server (conduit_direct stack) in
-        http  $ default_console $ filesfs $ tmplfs $ server
+        let clock = default_clock in
+        http  $ default_console $ filesfs $ tmplfs $ server $ clock
       | true ->
         let pr = get ~default:None "TRAVIS_PULL_REQUEST" opt_string_of_env in
         let secrets = get "SECRETS" ~default:`Crunch fat_of_env in

--- a/src/dispatch.ml
+++ b/src/dispatch.ml
@@ -1,5 +1,6 @@
 (*
  * Copyright (c) 2015 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2015 Citrix Inc
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -197,7 +198,12 @@ module Make_localhost
         notfound = (fun ~uri -> not_found ~uri ());
         redirect = (fun ~uri -> moved_permanently ~uri ());
       } in
-      Cowabloga.Dispatch.f io dispatch uri
+      (* Cowabloga hides the URI which we need for query parameters *)
+      if Uri.path uri = "/rrd_updates"
+      then S.respond_string ~status:`OK ~body:(Stats.get_rrd_updates uri) ()
+      else if Uri.path uri = "/rrd_timescales"
+      then S.respond_string ~status:`OK ~body:(Stats.get_rrd_timescales uri) ()
+      else Cowabloga.Dispatch.f io dispatch uri
     in
     let conn_closed (_,conn_id) =
       let cid = Cohttp.Connection.to_string conn_id in

--- a/src/dispatch.mli
+++ b/src/dispatch.mli
@@ -22,6 +22,7 @@ module type S =
   functor (FS: V1_LWT.KV_RO) ->
   functor (TMPL: V1_LWT.KV_RO) ->
   functor (S: Cohttp_lwt.Server) ->
+  functor (Clock: V1.CLOCK) ->
 sig
 
   type dispatch = Types.path -> Types.cowabloga Lwt.t
@@ -49,7 +50,7 @@ sig
   (** The type for HTTP callbacks. *)
 
   val start: ?host:string -> ?redirect:string ->
-    C.t -> FS.t -> TMPL.t -> s -> unit Lwt.t
+    C.t -> FS.t -> TMPL.t -> s -> unit -> unit Lwt.t
   (** The HTTP server's start function.
 
       {ul

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -75,7 +75,7 @@ module Make_localhost
     Lwt.return conf
 
   let start ?(host="localhost") ?redirect c fs tmpl stack keys _clock =
-    Stats.start ~sleep:OS.Time.sleep;
+    Stats.start ~sleep:OS.Time.sleep ~time:Clock.time;
     tls_init keys >>= fun cfg ->
     let callback = with_https ?redirect(`Https, host) c fs tmpl in
     let https flow = with_tls c cfg flow ~f:callback in

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -42,8 +42,8 @@ module Make_localhost
   module Http  = Cohttp_mirage.Server(TCP)
   module Https = Cohttp_mirage.Server(TLS)
 
-  module D  = Dispatch.Make_localhost(C)(FS)(TMPL)(Http)
-  module DS = Dispatch.Make_localhost(C)(FS)(TMPL)(Https)
+  module D  = Dispatch.Make_localhost(C)(FS)(TMPL)(Http)(Clock)
+  module DS = Dispatch.Make_localhost(C)(FS)(TMPL)(Https)(Clock)
 
   let log c fmt = Printf.ksprintf (C.log c) fmt
 

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -54,6 +54,9 @@ module Ds = struct
   }
 end
 
+let total_requests = ref 0
+let total_errors = ref 0
+
 let make_dss stats = [
   Ds.make ~name:"free_words" ~units:"words"
     ~description:"Number of words in the free list"
@@ -61,6 +64,12 @@ let make_dss stats = [
   Ds.make ~name:"live_words" ~units:"words"
     ~description:"Number of words of live data in the major heap, including the header words."
     ~value:(Rrd.VT_Int64 (Int64.of_int stats.Gc.live_words)) ~ty:Rrd.Gauge ~min:0.0 ();
+  Ds.make ~name:"requests_per_second" ~units:"requests/second"
+    ~description:"HTTP requests received per second"
+    ~value:(Rrd.VT_Int64 (Int64.of_int !total_requests)) ~ty:Rrd.Derive ~min:0.0 ();
+  Ds.make ~name:"errors_per_second" ~units:"responses/second"
+    ~description:"Unsuccessful HTTP responses per second"
+    ~value:(Rrd.VT_Int64 (Int64.of_int !total_errors)) ~ty:Rrd.Derive ~min:0.0 ();
   ]
 
 (** Create a rrd *)
@@ -120,6 +129,11 @@ let page () =
       <h1>Server statistics</h1>
       <p>
         Select a timescale: $List.concat timescales$
+      </p>
+      <h2>HTTP</h2>
+      <p>This charts shows the number of HTTP requests per second</p>
+      <p>
+        <div id="http"/>
       </p>
       <h2>Memory usage</h2>
       <p>This chart shows heap usage, divided into live_words and free_words. The values are stacked,

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -1,5 +1,6 @@
 (*
  * Copyright (c) 2015 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2015 Citrix Inc
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -16,54 +17,120 @@
 
 open Lwt.Infix
 
-let delay = 60. *. 2.
-let history = 100
+open Rrd
 
-let html_of_stat t =
-  let open Gc in
-  let k f =
-    let str = Printf.sprintf "%dk" (f / 1_000) in
-    Cow.Html.of_string str
-  in
-  let m f =
-    let str = Printf.sprintf "%.0fm" (f /. 1_000_000.) in
-    Cow.Html.of_string str
-  in
-  <:html<
-      <tr>
-      <td>$m (Gc.allocated_bytes ())$</td>
-      <td>$k t.heap_words$</td>
-      <td>$k t.live_words$</td>
-      </tr>
-    >>
+let timescales = Rrd_timescales.([
+  make ~name:"minute" ~num_intervals:120 ~interval_in_steps:1 ();
+  make ~name:"hour"   ~num_intervals:120 ~interval_in_steps:12 ();
+  make ~name:"day"    ~num_intervals:168 ~interval_in_steps:720 ();
+  make ~name:"year"   ~num_intervals:366 ~interval_in_steps:17280 ();
+])
 
-let html_of_stats ts =
-  <:html<
-    <table>
-    <tr>
-    <th>Allocated Bytes</th>
-    <th>Heap Words</th>
-    <th>Live Words</th>
-    </tr>
-    $list:List.map html_of_stat ts$
-    </table>
-   >>
+let create_rras use_min_max =
+  (* Create archives of type min, max and average and last *)
+  Array.of_list (List.flatten
+    (List.map (fun { Rrd_timescales.num_intervals; interval_in_steps } ->
+      if interval_in_steps > 1 && use_min_max then [
+        Rrd.rra_create Rrd.CF_Average num_intervals interval_in_steps 1.0;
+        Rrd.rra_create Rrd.CF_Min num_intervals interval_in_steps 1.0;
+        Rrd.rra_create Rrd.CF_Max num_intervals interval_in_steps 1.0;
+      ] else [Rrd.rra_create Rrd.CF_Average num_intervals interval_in_steps 0.5]
+    ) timescales)
+  )
 
-let stats = Queue.create ()
+let step = 5
+
+module Ds = struct
+  type t = {
+    name: string;
+    description: string;
+    value: Rrd.ds_value_type;
+    ty: Rrd.ds_type;
+    max: float;
+    min: float;
+    units: string;
+  }
+  let make ~name ~description ~value ~ty ~units
+    ?(min = neg_infinity) ?(max = infinity) () = {
+    name; description; value; ty; min; max; units
+  }
+end
+
+let make_dss stats = [
+  Ds.make ~name:"free_words" ~units:"words"
+    ~description:"Number of words in the free list"
+    ~value:(Rrd.VT_Int64 (Int64.of_int stats.Gc.free_words)) ~ty:Rrd.Gauge ~min:0.0 ();
+  Ds.make ~name:"live_words" ~units:"words"
+    ~description:"Number of words of live data in the major heap, including the header words."
+    ~value:(Rrd.VT_Int64 (Int64.of_int stats.Gc.live_words)) ~ty:Rrd.Gauge ~min:0.0 ();
+  ]
+
+(** Create a rrd *)
+let create_fresh_rrd use_min_max dss =
+  let rras = create_rras use_min_max in
+  let dss = Array.of_list (List.map (fun ds ->
+      Rrd.ds_create ds.Ds.name ds.Ds.ty ~mrhb:300.0 ~max:ds.Ds.max
+      ~min:ds.Ds.min Rrd.VT_Unknown
+    ) dss) in
+  let rrd = Rrd.rrd_create dss rras (Int64.of_int step) (Clock.time ()) in
+  rrd
+
+let update_rrds timestamp dss rrd =
+  Rrd.ds_update_named rrd timestamp ~new_domid:false
+    (List.map (fun ds -> ds.Ds.name, (ds.Ds.value, fun x -> x)) dss)
+
+let rrd = create_fresh_rrd true (make_dss (Gc.stat ()))
 
 let start ~sleep =
-  let gather () =
-    let stat = Gc.stat () in
-    if Queue.length stats >= history then ignore (Queue.pop stats);
-    Queue.push stat stats
-  in
   let rec loop () =
-    gather ();
-    sleep delay >>= fun () ->
-    loop ()
-  in
+    let timestamp = Clock.time () in
+    update_rrds timestamp (make_dss (Gc.stat ())) rrd;
+    sleep 5. >>= fun () ->
+    loop () in
   Lwt.async loop
 
 let page () =
-  let stats = Queue.fold (fun acc s -> s :: acc) [] stats in
-  html_of_stats stats
+  let timescales = List.map (fun t ->
+    let uri = "?timescale=" ^ t.Rrd_timescales.name in
+    <:html<
+    <a href="$str:uri$">$str:t.Rrd_timescales.name$</a>
+    >>
+  ) timescales in
+  <:html<
+    <head>
+      <meta charset="utf-8" />
+      <link href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.css" rel="stylesheet" type="text/css"/>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js"></script>
+      <script src="/js/stats/main.js"> </script>
+    </head>
+    <body>
+      <h1>GC statistics</h1>
+      <p>
+        $List.concat timescales$
+      </p>
+      <p>
+        <div id="chart"/>
+      </p>
+    </body>
+  >>
+
+let get_rrd_updates uri =
+  let query = Uri.query uri in
+  let get key =
+    if List.mem_assoc key query
+    then match List.assoc key query with
+      | [] -> None
+      | x :: _ -> Some x
+    else None in
+  let (>>=) m f = match m with None -> None | Some x -> f x in
+  let default d = function None -> d | Some x -> x in
+  let int64 x = try Some (Int64.of_string x) with _ -> None in
+  let cf x = try Some (Rrd.cf_type_of_string x) with _ -> None in
+  let start = default 0L (get "start" >>= int64) in
+  let interval = default 0L (get "interval" >>= int64) in
+  let cfopt = get "cf" >>= cf in
+  Rrd_updates.export [ "", rrd ] start interval cfopt
+
+let get_rrd_timescales uri =
+  Rrd_timescales.to_json timescales

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -91,7 +91,7 @@ let start ~sleep ~time =
         rrd
       end
     ) >>= fun rrd ->
-  
+
     let rec loop () =
       let timestamp = time () in
       update_rrds timestamp (make_dss (Gc.stat ())) rrd;
@@ -110,20 +110,22 @@ let page () =
   <:html<
     <head>
       <meta charset="utf-8" />
+      <title>Server statistics</title>
       <link href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.css" rel="stylesheet" type="text/css"/>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js" charset="utf-8"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js"></script>
       <script src="/js/stats/main.js"> </script>
     </head>
     <body>
-      <h1>Memory usage</h1>
+      <h1>Server statistics</h1>
       <p>
-        $List.concat timescales$
+        Select a timescale: $List.concat timescales$
       </p>
+      <h2>Memory usage</h2>
       <p>This chart shows heap usage, divided into live_words and free_words. The values are stacked,
          allowing you to see the total amount of memory being managed by OCaml.</p>
       <p>
-        <div id="chart"/>
+        <div id="memory"/>
       </p>
     </body>
   >>

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -105,10 +105,12 @@ let page () =
       <script src="/js/stats/main.js"> </script>
     </head>
     <body>
-      <h1>GC statistics</h1>
+      <h1>Memory usage</h1>
       <p>
         $List.concat timescales$
       </p>
+      <p>This chart shows heap usage, divided into live_words and free_words. The values are stacked,
+         allowing you to see the total amount of memory being managed by OCaml.</p>
       <p>
         <div id="chart"/>
       </p>

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -17,8 +17,6 @@
 
 open Lwt.Infix
 
-open Rrd
-
 let timescales = Rrd_timescales.([
   make ~name:"minute" ~num_intervals:120 ~interval_in_steps:1 ();
   make ~name:"hour"   ~num_intervals:120 ~interval_in_steps:12 ();
@@ -29,7 +27,7 @@ let timescales = Rrd_timescales.([
 let create_rras use_min_max =
   (* Create archives of type min, max and average and last *)
   Array.of_list (List.flatten
-    (List.map (fun { Rrd_timescales.num_intervals; interval_in_steps } ->
+  (List.map (fun { Rrd_timescales.num_intervals; interval_in_steps; _ } ->
       if interval_in_steps > 1 && use_min_max then [
         Rrd.rra_create Rrd.CF_Average num_intervals interval_in_steps 1.0;
         Rrd.rra_create Rrd.CF_Min num_intervals interval_in_steps 1.0;
@@ -148,5 +146,5 @@ let get_rrd_updates uri =
   let cfopt = get "cf" >>= cf in
   Lwt.return (Rrd_updates.export [ "", rrd ] start interval cfopt)
 
-let get_rrd_timescales uri =
+let get_rrd_timescales _ =
   Rrd_timescales.to_json timescales

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -16,11 +16,11 @@
 
 (** Gather statisticts about the application. *)
 
-val start: sleep:(float -> unit Lwt.t) -> unit
+val start: sleep:(float -> unit Lwt.t) -> time:(unit -> float) -> unit
 (** Start the monitor thread. *)
 
 val page: unit -> Cow.Html.t
 
-val get_rrd_updates: Uri.t -> string
+val get_rrd_updates: Uri.t -> string Lwt.t
 
 val get_rrd_timescales: Uri.t -> string

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -24,3 +24,9 @@ val page: unit -> Cow.Html.t
 val get_rrd_updates: Uri.t -> string Lwt.t
 
 val get_rrd_timescales: Uri.t -> string
+
+val total_requests: int ref
+(** Total number of HTTP requests received *)
+
+val total_errors: int ref
+(** Total number of HTTP error responses *)

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -20,4 +20,7 @@ val start: sleep:(float -> unit Lwt.t) -> unit
 (** Start the monitor thread. *)
 
 val page: unit -> Cow.Html.t
-(** Build a page describing the stats of the current application. *)
+
+val get_rrd_updates: Uri.t -> string
+
+val get_rrd_timescales: Uri.t -> string

--- a/stats/Makefile
+++ b/stats/Makefile
@@ -19,7 +19,7 @@ all:: build install
 
 install: build
 	mkdir -p ../files/js/stats
-	cp main.js ../files/js/stats/main.js
+	cp main.min.js ../files/js/stats/main.js
 
 depend::
 	$(OPAM) install $(PKGS) --verbose
@@ -27,7 +27,10 @@ depend::
 main.byte:
 	$(BUILD) main.byte
 
-build: main.js
+build: main.min.js
+
+main.min.js: main.js
+	jsoo_minify main.js
 
 main.js: main.byte
 	js_of_ocaml main.byte

--- a/stats/Makefile
+++ b/stats/Makefile
@@ -1,0 +1,38 @@
+LIBS   = -pkgs lwt.syntax,js_of_ocaml,js_of_ocaml.syntax,c3,uri,re.str,rrd,bigarray
+PKGS   = js_of_ocaml lwt c3 uri xapi-rrd re
+SYNTAX = -tags "syntax(camlp4o),annot,bin_annot,strict_sequence,principal,thread"
+
+SYNTAX += -tag-line "<static*.*>: -syntax(camlp4o)"
+
+FLAGS  = -cflag -g -lflags -g,-linkpkg
+
+BUILD  = ocamlbuild -use-ocamlfind $(LIBS) $(SYNTAX) $(FLAGS)
+OPAM   = opam
+
+export PKG_CONFIG_PATH=$(shell opam config var prefix)/lib/pkgconfig
+
+export OPAMVERBOSE=1
+export OPAMYES=1
+
+.PHONY: all depend clean build main.byte install
+all:: build install
+
+install: build
+	mkdir -p ../files/js/stats
+	cp main.js ../files/js/stats/main.js
+
+depend::
+	$(OPAM) install $(PKGS) --verbose
+
+main.byte:
+	$(BUILD) main.byte
+
+build: main.js
+
+main.js: main.byte
+	js_of_ocaml main.byte
+
+clean::
+	ocamlbuild -clean
+
+-include Makefile.user

--- a/stats/Makefile
+++ b/stats/Makefile
@@ -1,4 +1,4 @@
-LIBS   = -pkgs lwt.syntax,js_of_ocaml,js_of_ocaml.syntax,c3,uri,re.str,rrd,bigarray
+LIBS   = -pkgs lwt.syntax,js_of_ocaml,js_of_ocaml.syntax,js_of_ocaml.log,c3,uri,re.str,rrd,bigarray
 PKGS   = js_of_ocaml lwt c3 uri xapi-rrd re
 SYNTAX = -tags "syntax(camlp4o),annot,bin_annot,strict_sequence,principal,thread"
 

--- a/stats/Makefile
+++ b/stats/Makefile
@@ -33,7 +33,7 @@ main.min.js: main.js
 	jsoo_minify main.js
 
 main.js: main.byte
-	js_of_ocaml main.byte
+	js_of_ocaml +weak.js main.byte
 
 clean::
 	ocamlbuild -clean

--- a/stats/README.md
+++ b/stats/README.md
@@ -1,0 +1,2 @@
+This directory contains a client-side web application which is used by
+the /stats/gc URI from src/stats.ml.

--- a/stats/main.ml
+++ b/stats/main.ml
@@ -16,22 +16,12 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 open Lwt
 
 let do_get ~uri =
-  let method_ = "GET" in
-  let (res, w) = Lwt.task () in
-  let req = XmlHttpRequest.create () in
-
-  Firebug.console##log(Js.string (Uri.to_string uri));
-  req##_open (Js.string method_, Js.string (Uri.to_string uri), Js._true);
-  req##onreadystatechange <- Js.wrap_callback
-    (fun _ ->
-       (match req##readyState with
-                   | XmlHttpRequest.DONE ->
-                           Lwt.wakeup w (Js.to_string req##responseText)
-                   | _ -> ()));
-
-	req##send (Js.some (Js.string ""));
-  Lwt.on_cancel res (fun () -> req##abort ()) ;
-  res
+  let open XmlHttpRequest in
+  get (Uri.to_string uri)
+  >>= fun frame ->
+  if frame.code = 200
+  then return frame.content
+  else fail (Failure (Printf.sprintf "GET %s returned code %d" (Uri.to_string uri) frame.code))
 
 let chart = ref None
 

--- a/stats/main.ml
+++ b/stats/main.ml
@@ -1,0 +1,131 @@
+(* Copyright (c) 2015, Dave Scott <dave@recoil.org>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*)
+
+open Lwt
+
+let do_get ~uri =
+  let method_ = "GET" in
+  let (res, w) = Lwt.task () in
+  let req = XmlHttpRequest.create () in
+
+  Firebug.console##log(Js.string (Uri.to_string uri));
+  req##_open (Js.string method_, Js.string (Uri.to_string uri), Js._true);
+  req##onreadystatechange <- Js.wrap_callback
+    (fun _ ->
+       (match req##readyState with
+                   | XmlHttpRequest.DONE ->
+                           Lwt.wakeup w (Js.to_string req##responseText)
+                   | _ -> ()));
+
+	req##send (Js.some (Js.string ""));
+  Lwt.on_cancel res (fun () -> req##abort ()) ;
+  res
+
+let chart = ref None
+
+let colon = Re_str.regexp_string ":"
+
+let render_update timescale update =
+  let open Rrd_updates in
+  let window = Rrd_timescales.to_span timescale in
+	let _, legends = Array.fold_left
+	  (fun (idx, acc) elt ->
+      match Re_str.split_delim colon elt with
+      | [ "AVERAGE"; name ] ->
+       (idx + 1, (idx, name) :: acc)
+     | _ ->
+       Firebug.console##log(Js.string (elt));
+         (idx + 1, acc)
+    ) (0, []) update.legend in
+
+  let data = Array.to_list update.data in
+  let labels = List.map snd legends in
+  let chart = match !chart with
+  | Some x -> x
+  | None ->
+      let segments =
+        List.map
+          (fun (_, label) ->
+            C3.Segment.make ~label ~kind:`Area ~points:[] ()
+          ) legends in
+      let x =
+        C3.Line.make ~kind:`Timeseries ~x_format:"%H:%M:%S" ~x_label:"Time" ~y_label:"words" ()
+        |> C3.Line.add_group ~segments
+        |> C3.Line.render ~bindto:"#chart" in
+      chart := Some x;
+      x in
+
+  let x_min = Int64.to_float update.Rrd_updates.end_time -. (float_of_int window) in
+  let nans = List.map
+    (fun (idx, _) ->
+      Array.map (fun x -> classify_float x.row_data.(idx) = FP_nan) update.data
+    ) legends in
+  let segments =
+    List.map (fun (idx, legend) ->
+      let points = List.mapi (fun i x ->
+        (* if a NaN appears in any archive, set all the others to NaN too. *)
+        if List.fold_left (||) false (List.map (fun x -> x.(i)) nans)
+        then []
+        else [x.time, x.row_data.(idx)]
+      ) data |> List.concat in
+      Firebug.console##log(Js.string (Printf.sprintf "x_min = %f points = [| %s |]" x_min (String.concat "; " (List.map (fun (t, p) -> Printf.sprintf "%Ld %f" t p) points))));
+      if points <> []
+      then [ C3.Segment.make ~label:legend ~kind:`Area ~points:(List.map (fun (t, v) -> Int64.to_float t, v) points) () ]
+      else []
+    ) legends |> List.concat in
+  C3.Line.update ~segments chart
+
+let watch_rrds () =
+  let get key query =
+    if List.mem_assoc key query
+    then Some (List.assoc key query)
+    else None in
+  let default d = function None -> d | Some x -> x in
+  Firebug.console##log(Printf.sprintf "arguments = [ %s ]" (String.concat ", " (List.map (fun (k, v) -> k ^ ":" ^ v) Url.Current.arguments)));
+
+  let selected_timescale = default "minute" @@ get "?timescale" Url.Current.arguments in
+
+  do_get ~uri:(Uri.make ~scheme:"http" ~path:"/rrd_timescales" ())
+  >>= fun txt ->
+  let timescales = Rrd_timescales.of_json txt in
+
+  let timescale = List.find (fun t -> Rrd_timescales.name_of t = selected_timescale) timescales in
+
+  let uri start =
+    let query = [ "start", [ string_of_int start ]; "interval", [ string_of_int (Rrd_timescales.interval_to_span timescale)] ] in
+    Uri.make ~scheme:"http" ~path:"/rrd_updates" ~query () in
+
+  let window = Rrd_timescales.to_span timescale in
+
+  let rec loop start =
+    do_get ~uri:(uri start)
+    >>= fun txt ->
+    let input = Xmlm.make_input (`String (0, txt)) in
+    let update = Rrd_updates.of_xml input in
+    Firebug.console##log(Js.string "got some updates");
+    render_update timescale update;
+    Lwt_js.sleep 5.
+    >>= fun () ->
+    loop (-window + 1) in
+
+
+  loop (-window + 1)
+
+let _ =
+  Dom_html.window##onload <- Dom_html.handler
+    (fun _ ->
+      Lwt.async watch_rrds;
+      Js._true
+    )

--- a/stats/main.ml
+++ b/stats/main.ml
@@ -114,8 +114,4 @@ let watch_rrds () =
   loop (-window + 1)
 
 let _ =
-  Dom_html.window##onload <- Dom_html.handler
-    (fun _ ->
-      Lwt.async watch_rrds;
-      Js._true
-    )
+  Lwt_js_events.onload () >>= (fun _ -> watch_rrds ())

--- a/stats/main.ml
+++ b/stats/main.ml
@@ -29,7 +29,7 @@ let do_get ~uri =
     fail (Failure "GET failed")
   end
 
-let chart = ref None
+let memory = ref None
 
 let colon = Re_str.regexp_string ":"
 
@@ -47,7 +47,7 @@ let render_update timescale update =
 
   let data = Array.to_list update.data in
   let labels = List.map snd legends in
-  let chart = match !chart with
+  let memory = match !memory with
   | Some x -> x
   | None ->
       let segments =
@@ -58,8 +58,8 @@ let render_update timescale update =
       let x =
         C3.Line.make ~kind:`Timeseries ~x_format:"%H:%M:%S" ~x_label:"Time" ~y_label:"words" ()
         |> C3.Line.add_group ~segments
-        |> C3.Line.render ~bindto:"#chart" in
-      chart := Some x;
+        |> C3.Line.render ~bindto:"#memory" in
+      memory := Some x;
       x in
 
   let x_min = Int64.to_float update.Rrd_updates.end_time -. (float_of_int window) in
@@ -79,7 +79,7 @@ let render_update timescale update =
       then [ C3.Segment.make ~label:legend ~kind:`Area ~points:(List.map (fun (t, v) -> Int64.to_float t, v) points) () ]
       else []
     ) legends |> List.concat in
-  C3.Line.update ~segments chart
+  C3.Line.update ~segments memory
 
 let watch_rrds () =
   let get key query =


### PR DESCRIPTION
Depends on: [ocaml/opam-repository#4313]
Depends on: [ocaml/opam-repository#4314]

src/stats.ml renders a page which references javascript built
from stats/main.ml via js_of_ocaml.

The stats/main.ml fetches updates in RRD export format from
the URI /rrd_updates, in the same way as [xapi-project/xen-api].

A background thread in src/stats.ml feeds Gc.stats() data into
RRDs via [xapi-project/xcp-rrd].

The stats/main.ml runs in the browser and draws/animates graphs
using OCaml bindings to the C3 library, built on top of D3.

Signed-off-by: David Scott <dave.scott@citrix.com>

![rrd](https://cloud.githubusercontent.com/assets/198586/8364705/198fcab4-1b80-11e5-87e0-d173d3a05355.png)
