### PR TITLE
Enable tracing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,19 @@ env:
   - OCAML_VERSION=4.02 MIRAGE_BACKEND=unix FLAGS="-vv --net socket"
   - OCAML_VERSION=4.02 MIRAGE_BACKEND=unix FLAGS="-vv --net direct"
   - OCAML_VERSION=4.02 MIRAGE_BACKEND=xen  DEPLOY=1 XENIMG="openmirage.org"
-    PINS="mirage-net-xen:1.4.2"
+    PINS="mirage-net-xen:1.4.2 lwt:https://github.com/talex5/lwt.git#tracing"
     FLAGS="-vv --net direct --dhcp false --ip 46.43.42.147
     --netmask 255.255.255.128 --gateways 46.43.42.129 --tls false
     --host openmirage.org --redirect https://mirage.io --network 0"
     UPDATE_GCC_BINUTILS=1
   - OCAML_VERSION=4.02 MIRAGE_BACKEND=xen DEPLOY=1 XENIMG="mirage.io"
-    PINS="mirage-net-xen:1.4.2"
+    PINS="mirage-net-xen:1.4.2 lwt:https://github.com/talex5/lwt.git#tracing"
     FLAGS="-vv --net direct --dhcp false --ip 46.43.42.146
     --netmask 255.255.255.128 --gateways 46.43.42.129 --tls true
     --secrets-kv_ro fat --host mirage.io --network 0"
     UPDATE_GCC_BINUTILS=1
   global:
+  - PINS="mirage-profile lwt:https://github.com/talex5/lwt.git#tracing"
   - secure: PUu3+Enupf9jcIPD/hs5b6zrNuJagTDXJGtYfSUIFvzevSXZzs6mXPu8L2vvAQbQ8ig/8VLToa44vUTG9OEy9SxXrR6yTQGfj4YxJ5BXKHwhYMTBXnR1e+S1gA4a5tilMa7M/a0hWa1rORv3diMIK3dihjc1m6VzpCK/4vly7KU=
   - secure: crnwZ3MDUA9szI/EuwB9o7plXVF2QCx+JpOazy4SwC2v47Vf5voOEAxh7iFMgGziBqzKGVnDw4/37WHVm5vdgaL4lL2T73F1PqXbiCdhhwZVcf+EAXr8KmoaNXRieL7qPsemQVvPWUiERZRmR2okvm60EqifZA9/dy/48dJIGMI=
   - secure: JijSTl0jOOPL0HoWooCBnhokjqboQSgwy3orgG5nUIPrluthNjix4ujds9TOuEtv2pflbgptUUdYJ7R6VfeZk/UWIVUbwBRjtMJRQRDPB0jxyoL9VLGzTwfdovwV0Rg0jeJkBWsAJjIxkdawE2R4wexAOn/tWDiLaSQh/n096Fc=

--- a/src/config.ml
+++ b/src/config.ml
@@ -87,8 +87,7 @@ let libraries = [ "cow"; "cowabloga"; "rrd" ]
 let packages  = [ "cow"; "cowabloga"; "xapi-rrd"; "c3" ]
 
 let () =
-  let tracing = None in
-  (* let tracing = mprof_trace ~size:10000 () in *)
+  let tracing = Some (mprof_trace ~size:1000000 ()) in
   register ?tracing ~libraries ~packages image [
     dispatch $ default_console $ filesfs $ tmplfs $ default_clock
   ]


### PR DESCRIPTION
This might help us find out why the web-site sometimes stops. Ensure it is deployed with `on_poweroff = 'preserve'` in the `.xl` config file so we can still read the trace if the domain crashes.

To dump the trace, run:

```
mirage-trace-viewer -d www -w trace.ctf
```

There are pre-compiled binaries of mtv here: http://talex5.github.io/mirage-trace-viewer/mtv.xml (hopefully these will run from dom0, unless it's a really old OS).

It would be a good idea to look at @djs55's stats after deploying this to check the overhead isn't too big.
