### PR TITLE
increase font size (to 100%) and line height (to 1.2) in code blocks

### DIFF
--- a/files/css/site.css
+++ b/files/css/site.css
@@ -33,7 +33,8 @@ body {
 code {
   font-weight: normal;
   margin-bottom: 1em;
-  font-size: 90%;
+  font-size: 100%;
+  line-height: 1.2;
   word-break: break-all;
   word-wrap: break-word;
 }


### PR DESCRIPTION
I find the current formatting of code blocks a bit difficult to read.  I increased the font size from 90% to 100%, which caused the lines to run together, so I've also increased the line height.  I find it a bit more readable this way and it doesn't appear to have dramatically broken display of the code blocks I could find, at least on Firefox...