### PR TITLE
Replaced `make run` with binary names

### DIFF
--- a/tmpl/wiki/hello-world.md
+++ b/tmpl/wiki/hello-world.md
@@ -318,7 +318,7 @@ mirage configure --unix
 make depend
 make
 less static1.ml # the generated filesystem
-make run
+./mir-kv_ro
 mirage configure --xen
 make depend
 make
@@ -478,7 +478,7 @@ before trying this.
 $ cd stackv4
 $ mirage configure --unix
 $ make
-$ sudo make run
+$ ./mir-stackv4
 ```
 
 This Unix application is now listening simultaneously on the local


### PR DESCRIPTION
Apparently make run doesn't work... So they are replaced with the name of the binary that's generated.
Only `--unix` examples are fixed... I don't know how to do Xen.