### PR TITLE
typo

### DIFF
--- a/tmpl/wiki/weekly/2015-08-26.md
+++ b/tmpl/wiki/weekly/2015-08-26.md
@@ -38,8 +38,8 @@ generally we're in good shape to start getting command line tools in place to
 get the libraries out there, then go for the Full Mirage Experience.
 
 Discussion about ongoing `blockdev` naming, `.xl` generation etc. @dave felt PR
-ok but Travis was having some problems. He'll take lead on merging
-[ ed: and this is now done I think? ]
+ok but Travis was having some problems. He'll take lead on merging. (_ed: and
+this is now done I think._)
 
 Some discussion of grim @mort patch to get environment variable parsing into the
 `mirage` CLI tool. Agreement it was indeed grim and @samoht would not merge :)
@@ -83,7 +83,9 @@ maintain. Workarounds will be incoming as PRs; the first (#268) will be merged.
 to two issues: updates not being pushed, and the process for updating the index
 being manual and not always being done.
 
-[ ed: I note that three updates seem to be required-- adding the notes themselves under `/tmpl/wiki/weekly/`, adding a reference in `src/data.ml`, and adding a link to `/tmpl/wiki/index.md`. ]
+(_ed: I note that three updates seem to be required-- adding the notes
+themselves under `/tmpl/wiki/weekly/`, adding a reference in `src/data.ml`, and
+adding a link to `/tmpl/wiki/index.md`._)
 
 ### Jitsu on Monk
 


### PR DESCRIPTION
`[ ... ]` gets interpreted in some way that prevents markdown inside the `[ ... ]` being interpreted. which looks poor. 