### PR TITLE
[not for merge] Mirage-www, functoria edition.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,5 @@
 PKG cohttp cow cowabloga cstruct lwt mirage mirage-unix mirage-http
 PKG mirage-net-unix mirage-clock-unix mirage-console.unix mirage-fs-unix
 
-B src/_build/
-B src/build/**
+B src/_build/**
 S src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,17 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-mirage.sh
 env:
   matrix:
-  - OCAML_VERSION=4.02 FLAGS=-vv MIRAGE_BACKEND=unix MIRAGE_NET=socket
-  - OCAML_VERSION=4.02 FLAGS=-vv MIRAGE_BACKEND=unix MIRAGE_NET=direct
-  - OCAML_VERSION=4.02 FLAGS=-vv MIRAGE_BACKEND=xen  DEPLOY=1 XENIMG="openmirage.org"
-    IP="46.43.42.147" NETMASK="255.255.255.128" GATEWAYS="46.43.42.129"
-    TLS=0 HOST="openmirage.org" REDIRECT="https://mirage.io"
+  - OCAML_VERSION=4.02 MIRAGE_BACKEND=unix FLAGS="-vv --net socket"
+  - OCAML_VERSION=4.02 MIRAGE_BACKEND=unix FLAGS="-vv --net direct"
+  - OCAML_VERSION=4.02 MIRAGE_BACKEND=xen  DEPLOY=1 XENIMG="openmirage.org"
+    FLAGS="-vv --net direct --dhcp false --ip 46.43.42.147 \
+    --netmask 255.255.255.128 --gateways 46.43.42.129 --tls false \
+    --host openmirage.org --redirect https://mirage.io"
     UPDATE_GCC_BINUTILS=1
-  - OCAML_VERSION=4.02 FLAGS=-vv MIRAGE_BACKEND=xen DEPLOY=1 XENIMG="mirage.io"
-    IP="46.43.42.146" NETMASK="255.255.255.128" GATEWAYS="46.43.42.129"
-    TLS=1 HOST="mirage.io" SECRETS=fat
+  - OCAML_VERSION=4.02 MIRAGE_BACKEND=xen DEPLOY=1 XENIMG="mirage.io"
+    FLAGS="-vv --net direct --dhcp false --ip 46.43.42.146 \
+    --netmask 255.255.255.128 --gateways 46.43.42.129 --tls true \
+    --secrets-kv_ro fat --host mirage.io"
     UPDATE_GCC_BINUTILS=1
   global:
   - secure: PUu3+Enupf9jcIPD/hs5b6zrNuJagTDXJGtYfSUIFvzevSXZzs6mXPu8L2vvAQbQ8ig/8VLToa44vUTG9OEy9SxXrR6yTQGfj4YxJ5BXKHwhYMTBXnR1e+S1gA4a5tilMa7M/a0hWa1rORv3diMIK3dihjc1m6VzpCK/4vly7KU=

--- a/src/config.ml
+++ b/src/config.ml
@@ -102,15 +102,17 @@ let keys = Key.[ abstract host_key ; abstract redirect_key ]
 
 let image = get "XENIMG" ~default:"www" string_of_env
 
-let filesfs = generic_kv_ro ~group:"file" "../files"
-let tmplfs = generic_kv_ro ~group:"tmpl" "../tmpl"
+let fs_key = Key.(value @@ kv_ro ())
+let filesfs = generic_kv_ro ~key:fs_key "../files"
+let tmplfs = generic_kv_ro ~key:fs_key "../tmpl"
 
 (* If we are running inside a PR in Travis CI,
    we don't try to get the server certificates. *)
+let secrets_key = Key.(value @@ kv_ro ~group:"secrets" ())
 let secrets =
   if_impl (Key.value pr_key)
     (crunch "../src")
-    (generic_kv_ro ~group:"secret" "../tls")
+    (generic_kv_ro ~key:secrets_key "../tls")
 
 let stack = generic_stackv4 default_console tap0
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -68,44 +68,35 @@ let get ~default name fn =
     env_info "%s => not set." name;
     default
 
-let fs = get "FS" ~default:`Crunch fat_of_env
-let deploy = get "DEPLOY" ~default:false bool_of_env
-let net = get  "NET" ~default:`Direct socket_of_env
-let dhcp = get "DHCP" ~default:false bool_of_env
-let tls = get "TLS" ~default:false bool_of_env
+let tls_key =
+  let doc = Key.Arg.info
+      ~doc:"Enable serving the website over https."
+      ~env:"TLS" ["tls"]
+  in
+  Key.(create "tls" Arg.(opt ~stage:`Configure bool false doc))
+
+let pr_key =
+  let doc = Key.Arg.info
+      ~doc:"Configuration for running inside a travis PR."
+      ~env:"TRAVIS_PULL_REQUEST" ["pr"]
+  in
+  Key.(create "pr" Arg.(flag ~stage:`Configure doc))
+
 let host = get "HOST" ~default:None opt_string_of_env
 let redirect = get "REDIRECT" ~default:None opt_string_of_env
 let image = get "XENIMG" ~default:"www" string_of_env
 
-let mkfs fs path =
-  let fat_of_files dir = kv_ro_of_fs (fat_of_files ~dir ()) in
-  match fs, get_mode () with
-  | `Fat   , _    -> fat_of_files path
-  | `Archive, _   -> archive_of_files ~dir:path ()
-  | `Crunch, `Xen -> crunch path
-  | `Crunch, _    -> direct_kv_ro path
+let filesfs = generic_kv_ro ~group:"file" "../files"
+let tmplfs = generic_kv_ro ~group:"tmpl" "../tmpl"
 
-let filesfs = mkfs fs "../files"
-let tmplfs = mkfs fs "../tmpl"
-let cons0 = default_console
+(* If we are running inside a PR in Travis CI,
+   we don't try to get the server certificates. *)
+let secrets =
+  if_impl (Key.value pr_key)
+    (crunch "../src")
+    (generic_kv_ro ~group:"secret" "../tls")
 
-let stack = match deploy with
-  | true ->
-    let staticip =
-      let address = get_exn "IP" Ipaddr.V4.of_string_exn in
-      let netmask = get_exn "NETMASK" Ipaddr.V4.of_string_exn in
-      let gateways = get_exn "GATEWAYS" ips_of_env in
-      { address; netmask; gateways }
-    in
-    direct_stackv4_with_static_ipv4 cons0 tap0 staticip
-  | false ->
-    match net, dhcp with
-    | `Direct, false -> direct_stackv4_with_default_ipv4 cons0 tap0
-    | `Direct, true  -> direct_stackv4_with_dhcp cons0 tap0
-    | `Socket, _     -> socket_stackv4 cons0 [Ipaddr.V4.any]
-
-let libraries = [ "cow.syntax"; "cowabloga"; "rrd" ]
-let packages  = [ "cow"; "cowabloga"; "xapi-rrd"; "c3" ]
+let stack = generic_stackv4 default_console tap0
 
 let sp = Printf.sprintf
 
@@ -117,40 +108,34 @@ let config =
 let main = sp "Make(%s)" config
 
 let http =
-  foreign ~libraries ~packages ("Dispatch." ^ main)
+  foreign ("Dispatch." ^ main)
     (console @-> kv_ro @-> kv_ro @-> http @-> clock @-> job)
 
 let https =
-  let libraries = "tls" :: "tls.mirage" :: "mirage-http" :: libraries in
-  let packages = "tls" :: "tls" :: "mirage-http" :: packages in
+  let libraries = [ "tls"; "tls.mirage"; "mirage-http" ] in
+  let packages = ["tls"; "tls"; "mirage-http"] in
   foreign ~libraries ~packages ("Dispatch_tls." ^ main)
     ~deps:[abstract nocrypto]
     (console @-> kv_ro @-> kv_ro @-> stackv4 @-> kv_ro @-> clock @-> job)
 
-let err fmt = Printf.ksprintf (fun msg ->
-    Printf.eprintf "\n\027[31m[ERROR]\027[m     %s, stopping.\n%!" msg;
-    exit 1
-  ) fmt
+
+let dispatch = if_impl (Key.value tls_key)
+    (** With tls *)
+    begin
+      let clock = default_clock in
+      https $ default_console $ filesfs $ tmplfs $ stack $ secrets $ clock
+    end
+    (** Without tls *)
+    begin
+      let server = http_server (conduit_direct stack) in
+      let clock = default_clock in
+      http  $ default_console $ filesfs $ tmplfs $ server $ clock
+    end
+
+let libraries = [ "cow.syntax"; "cowabloga"; "rrd" ]
+let packages  = [ "cow"; "cowabloga"; "xapi-rrd"; "c3" ]
 
 let () =
   let tracing = None in
   (* let tracing = mprof_trace ~size:10000 () in *)
-  register ?tracing image [ match tls with
-      | false ->
-        let server = http_server (conduit_direct stack) in
-        let clock = default_clock in
-        http  $ default_console $ filesfs $ tmplfs $ server $ clock
-      | true ->
-        let pr = get ~default:None "TRAVIS_PULL_REQUEST" opt_string_of_env in
-        let secrets = get "SECRETS" ~default:`Crunch fat_of_env in
-        let clock = default_clock in
-        let tls =
-          match pr with
-          | None | Some "false" -> mkfs secrets "../tls"
-          | _ ->
-            (* we are running inside a PR in Travis CI. Don't try to
-               get the server certificates. *)
-            mkfs `Crunch "../src"
-        in
-        https $ default_console $ filesfs $ tmplfs $ stack $ tls $ clock
-    ]
+  register ?tracing ~libraries ~packages image [ dispatch ]

--- a/src/dispatch.ml
+++ b/src/dispatch.ml
@@ -34,8 +34,9 @@ let domain_of_string x =
   scheme, host
 
 module Make
+    (S: Cohttp_lwt.Server)
     (C: V1_LWT.CONSOLE) (FS: V1_LWT.KV_RO) (TMPL: V1_LWT.KV_RO)
-    (S: Cohttp_lwt.Server) (Clock: V1.CLOCK)
+    (Clock: V1.CLOCK)
 = struct
 
   type dispatch = Types.path -> Types.cowabloga Lwt.t
@@ -217,7 +218,7 @@ module Make
     in
     S.make ~callback ~conn_closed ()
 
-  let start c fs tmpl http () =
+  let start http c fs tmpl () =
     let host = Key_gen.host () in
     let red = Key_gen.redirect () in
     Stats.start ~sleep:OS.Time.sleep ~time:Clock.time;

--- a/src/dispatch.mli
+++ b/src/dispatch.mli
@@ -18,10 +18,10 @@
 
 (** The HTTP dispatcher. *)
 module Make
+    (S: Cohttp_lwt.Server)
     (C: V1_LWT.CONSOLE)
     (FS: V1_LWT.KV_RO)
     (TMPL: V1_LWT.KV_RO)
-    (S: Cohttp_lwt.Server)
     (Clock: V1.CLOCK) :
 sig
 
@@ -49,7 +49,7 @@ sig
   type s = Conduit_mirage.server -> S.t -> unit Lwt.t
   (** The type for HTTP callbacks. *)
 
-  val start: C.t -> FS.t -> TMPL.t -> s -> unit -> unit Lwt.t
+  val start: s -> C.t -> FS.t -> TMPL.t -> unit -> unit Lwt.t
   (** The HTTP server's start function. *)
 
 end

--- a/src/dispatch.mli
+++ b/src/dispatch.mli
@@ -16,13 +16,13 @@
 
 (** HTTP dispatcher *)
 
-(** The signature for HTTP dispatcher. *)
-module type S =
-  functor (C: V1_LWT.CONSOLE) ->
-  functor (FS: V1_LWT.KV_RO) ->
-  functor (TMPL: V1_LWT.KV_RO) ->
-  functor (S: Cohttp_lwt.Server) ->
-  functor (Clock: V1.CLOCK) ->
+(** The HTTP dispatcher. *)
+module Make
+    (C: V1_LWT.CONSOLE)
+    (FS: V1_LWT.KV_RO)
+    (TMPL: V1_LWT.KV_RO)
+    (S: Cohttp_lwt.Server)
+    (Clock: V1.CLOCK) :
 sig
 
   type dispatch = Types.path -> Types.cowabloga Lwt.t
@@ -49,34 +49,10 @@ sig
   type s = Conduit_mirage.server -> S.t -> unit Lwt.t
   (** The type for HTTP callbacks. *)
 
-  val start: ?host:string -> ?redirect:string ->
-    C.t -> FS.t -> TMPL.t -> s -> unit -> unit Lwt.t
-  (** The HTTP server's start function.
-
-      {ul
-      {- If [host] is not set, use an implementation specific default}
-      {- If [redirect] is set, all the paths will be redirected to the
-         given domain}} *)
+  val start: C.t -> FS.t -> TMPL.t -> s -> unit -> unit Lwt.t
+  (** The HTTP server's start function. *)
 
 end
-
-module type Config = sig
-  (** Website configuration. *)
-
-  val host: string option
-  (** Configure the host name. *)
-
-  val redirect: string option
-  (** If set, redirect all paths to the the given domain. *)
-end
-
-module Make_localhost: S
-(** Instantiate an implementation of {!S} using ["localhost"] as
-    default host in {!S.start}. *)
-
-module Make (Config: Config): S
-(** Instantiate an implementation of {!S} using [Config.host] as
-    default host in {!S.start}. *)
 
 val domain_of_string: string -> Types.domain
 (** [domain_of_string d] parses the string [d] to build a

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -17,8 +17,10 @@
 open Lwt.Infix
 
 module Make
-    (C: V1_LWT.CONSOLE) (FS: V1_LWT.KV_RO) (TMPL: V1_LWT.KV_RO)
-    (S: V1_LWT.STACKV4) (KEYS: V1_LWT.KV_RO) (Clock : V1.CLOCK)
+    (S: V1_LWT.STACKV4) (KEYS: V1_LWT.KV_RO)
+
+    (C: V1_LWT.CONSOLE) (FS: V1_LWT.KV_RO)
+    (TMPL: V1_LWT.KV_RO) (Clock : V1.CLOCK)
 = struct
 
 
@@ -30,8 +32,8 @@ module Make
   module Http  = Cohttp_mirage.Server(TCP)
   module Https = Cohttp_mirage.Server(TLS)
 
-  module D  = Dispatch.Make(C)(FS)(TMPL)(Http)(Clock)
-  module DS = Dispatch.Make(C)(FS)(TMPL)(Https)(Clock)
+  module D  = Dispatch.Make(Http)(C)(FS)(TMPL)(Clock)
+  module DS = Dispatch.Make(Https)(C)(FS)(TMPL)(Clock)
 
   let log c fmt = Printf.ksprintf (C.log c) fmt
 
@@ -54,7 +56,7 @@ module Make
     let conf = Tls.Config.server ~certificates:(`Single cert) () in
     Lwt.return conf
 
-  let start c fs tmpl stack keys _clock () =
+  let start stack keys  c fs tmpl _clock () =
     let host = Key_gen.host () in
     let redirect = Key_gen.redirect () in
     Stats.start ~sleep:OS.Time.sleep ~time:Clock.time;

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -16,19 +16,7 @@
 
 open Lwt.Infix
 
-module type S =
-  functor (C: V1_LWT.CONSOLE) ->
-  functor (FS: V1_LWT.KV_RO) ->
-  functor (TMPL: V1_LWT.KV_RO) ->
-  functor (S: V1_LWT.STACKV4) ->
-  functor (KEYS: V1_LWT.KV_RO) ->
-  functor (Clock : V1.CLOCK) ->
-sig
-  val start: ?host:string -> ?redirect:string ->
-    C.t -> FS.t -> TMPL.t -> S.t -> KEYS.t -> unit -> unit -> unit Lwt.t
-end
-
-module Make_localhost
+module Make
     (C: V1_LWT.CONSOLE) (FS: V1_LWT.KV_RO) (TMPL: V1_LWT.KV_RO)
     (S: V1_LWT.STACKV4) (KEYS: V1_LWT.KV_RO) (Clock : V1.CLOCK)
 = struct
@@ -42,8 +30,8 @@ module Make_localhost
   module Http  = Cohttp_mirage.Server(TCP)
   module Https = Cohttp_mirage.Server(TLS)
 
-  module D  = Dispatch.Make_localhost(C)(FS)(TMPL)(Http)(Clock)
-  module DS = Dispatch.Make_localhost(C)(FS)(TMPL)(Https)(Clock)
+  module D  = Dispatch.Make(C)(FS)(TMPL)(Http)(Clock)
+  module DS = Dispatch.Make(C)(FS)(TMPL)(Https)(Clock)
 
   let log c fmt = Printf.ksprintf (C.log c) fmt
 
@@ -66,7 +54,9 @@ module Make_localhost
     let conf = Tls.Config.server ~certificates:(`Single cert) () in
     Lwt.return conf
 
-  let start ?(host="localhost") ?redirect c fs tmpl stack keys _clock () =
+  let start c fs tmpl stack keys _clock () =
+    let host = Key_gen.host () in
+    let redirect = Key_gen.redirect () in
     Stats.start ~sleep:OS.Time.sleep ~time:Clock.time;
     tls_init keys >>= fun cfg ->
     let domain = `Https, host in
@@ -81,15 +71,4 @@ module Make_localhost
     S.listen_tcpv4 stack ~port:80  http;
     S.listen stack
 
-end
-
-module Make (Config: Dispatch.Config)
-    (C: V1_LWT.CONSOLE) (FS: V1_LWT.KV_RO) (TMPL: V1_LWT.KV_RO)
-    (S: V1_LWT.STACKV4) (KEYS: V1_LWT.KV_RO) (Clock : V1.CLOCK)
-= struct
-  module M = Make_localhost(C)(FS)(TMPL)(S)(KEYS)(Clock)
-  let start ?host ?redirect c fs tmpl stack keys _clock () =
-    let host = match host with None -> Config.host | x -> x in
-    let redirect = match redirect with None -> Config.redirect | x -> x in
-    M.start ?host ?redirect c fs tmpl stack keys _clock ()
 end

--- a/src/dispatch_tls.mli
+++ b/src/dispatch_tls.mli
@@ -18,15 +18,16 @@
 
 (** The HTTP dispatcher. *)
 module Make
+    (S: V1_LWT.STACKV4)
+    (KEYS: V1_LWT.KV_RO)
     (C: V1_LWT.CONSOLE)
     (FS: V1_LWT.KV_RO)
     (TMPL: V1_LWT.KV_RO)
-    (S: V1_LWT.STACKV4)
-    (KEYS: V1_LWT.KV_RO)
     (Clock : V1.CLOCK) :
 sig
 
   val start:
-    C.t -> FS.t -> TMPL.t -> S.t -> KEYS.t -> unit -> unit -> unit Lwt.t
+    S.t -> KEYS.t ->
+    C.t -> FS.t -> TMPL.t -> unit -> unit -> unit Lwt.t
     (** The HTTP server's start function. *)
 end

--- a/src/dispatch_tls.mli
+++ b/src/dispatch_tls.mli
@@ -16,27 +16,17 @@
 
 (** HTTPS dispatcher *)
 
-(** The signature for HTTP dispatcher. *)
-module type S =
-  functor (C: V1_LWT.CONSOLE) ->
-  functor (FS: V1_LWT.KV_RO) ->
-  functor (TMPL: V1_LWT.KV_RO) ->
-  functor (S: V1_LWT.STACKV4) ->
-  functor (KEYS: V1_LWT.KV_RO) ->
-  functor (Clock : V1.CLOCK) ->
+(** The HTTP dispatcher. *)
+module Make
+    (C: V1_LWT.CONSOLE)
+    (FS: V1_LWT.KV_RO)
+    (TMPL: V1_LWT.KV_RO)
+    (S: V1_LWT.STACKV4)
+    (KEYS: V1_LWT.KV_RO)
+    (Clock : V1.CLOCK) :
 sig
 
-  val start: ?host:string -> ?redirect:string ->
+  val start:
     C.t -> FS.t -> TMPL.t -> S.t -> KEYS.t -> unit -> unit -> unit Lwt.t
-  (** The HTTP server's start function. If [host] is not set, use an
-      implementation specific default. *)
-
+    (** The HTTP server's start function. *)
 end
-
-module Make_localhost: S
-(** Instantiate an implementation of {!S} using ["localhost"] as
-    default host in {!S.start}. *)
-
-module Make (Config: Dispatch.Config): S
-(** Instantiate an implementation of {!S} using [Config.host] as
-    default host in {!S.start}. *)


### PR DESCRIPTION
This should not be merged, the deployment scripts are not updated.
I did this to "try it out" (and see the pretty graph at the end, really).

The commit first two commits fix compat. The rest is just for goodies and self-documentation:

Here is the graph visible by the user with mirage describe before conversion to functoria:
![Mirage-www before](https://i.imgur.com/OcyabqQ.png).

You can clearly see the network stack on the right bottom and the user functor on the top.

Then I used the combinators now available to rewrite the config file and to improve the code in general.
Here are the help pages for the [configure](https://gist.github.com/Drup/fca9a172ca7123eafaff#file-configure-help-page-for-mirage-www) and for the [actual unikernel](https://gist.github.com/Drup/fca9a172ca7123eafaff#file-runtime-help-page-for-mirage-www)
I should probably merge the various kv_ro option.

Here is the dot output for the whole mirage-www:
![Mirage-www after](https://i.imgur.com/MjLysI4.png)

This is quite big. The generic network stack (dhcp + static + socket) is on the bottom left, key/value stores are on the right and you can see the two dispatch modules in the middle.

It is possible to cut down the graph by instanciating some of the options. Here is the graph full evaluated with the *socket* stack and tls *enabled*:

![Mirage-www socket and tls](https://i.imgur.com/mee0eMl.png)