### PR TITLE
add links to devel.unikernel.org

### DIFF
--- a/tmpl/blog/hackathon-marrakech2016.md
+++ b/tmpl/blog/hackathon-marrakech2016.md
@@ -1,3 +1,7 @@
 The first MirageOS hackathon will take place in Marrakech, Morocco, from 11th till 16th March 2016.  It is open for everybody.  The main goal is to get together people motivated to contribute to MirageOS.
 
 Find more details on [the hackathon website](http://marrakech2016.mirage.io).
+
+*Edit: discuss this post on [devel.unikernel.org][discuss]*
+
+[discuss]: http://devel.unikernel.org/t/1st-mirageos-hackathon/24/1

--- a/tmpl/blog/hackathon-marrakech2016.md
+++ b/tmpl/blog/hackathon-marrakech2016.md
@@ -4,4 +4,4 @@ Find more details on [the hackathon website](http://marrakech2016.mirage.io).
 
 *Edit: discuss this post on [devel.unikernel.org][discuss]*
 
-[discuss]: http://devel.unikernel.org/t/1st-mirageos-hackathon/24/1
+[discuss]: https://devel.unikernel.org/t/1st-mirageos-hackathon/24/1

--- a/tmpl/blog/unikernel-org.md
+++ b/tmpl/blog/unikernel-org.md
@@ -36,7 +36,7 @@ improving unikernels!
 
 *Edit: discuss this post on [devel.unikernel.org][discuss]*
 
-[discuss]: http://devel.unikernel.org/t/why-we-need-unikernel-org/18/1
+[discuss]: https://devel.unikernel.org/t/why-we-need-unikernel-org/18/1
 
 *Thanks to [Anil][], [Jeremy][] and [Mindy][] for
 comments on an earlier draft.*

--- a/tmpl/blog/unikernel-org.md
+++ b/tmpl/blog/unikernel-org.md
@@ -34,6 +34,10 @@ contributors across all the projects.
 Please do visit the site and contribute stories about how you're using and
 improving unikernels!
 
+*Edit: discuss this post on [devel.unikernel.org][discuss]*
+
+[discuss]: http://devel.unikernel.org/t/why-we-need-unikernel-org/18/1
+
 *Thanks to [Anil][], [Jeremy][] and [Mindy][] for
 comments on an earlier draft.*
 


### PR DESCRIPTION
We can use [devel.unikernel.org](http://devel.unikernel.org) for any discussions on blog posts. I've added links to the two recent posts.

We've not had any comment functionality on the site so this can fill that gap.