### PR TITLE
Update the instructions to build the website.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /src/mir-main
 /src/main.native
 /src/www.xl
+/src/www.xl.in
+/src/key_gen.ml
 /src/www.xe
 /src/www_libvirt.xml
 
@@ -22,8 +24,7 @@
 /src/static[0-9].ml
 /src/static[0-9].mli
 /src/fat*.img
-/src/make-fat1-image.sh
-/src/make-fat2-image.sh
+/src/make-fat*.sh
 
 files/js/stats
 

--- a/Makefile
+++ b/Makefile
@@ -16,50 +16,25 @@
 # PERFORMANCE OF THIS SOFTWARE.
 #
 
-# MODE: unix for Unix executable, xen for Xen unikernel
-MODE   ?= unix
-# FS: crunch for in-memory read-only store, fat for read-write filesystem
-FS     ?= crunch
-# NET: direct for mirage network stack, socket for unix sockets (Unix mode only)
-NET    ?= direct
 # XENIMG: the name to provide for the xen image and configuration
 XENIMG ?= www
-# HOST: all links will be relative to this domain; default is localhost
-HOST   ?= localhost
 
-# to configure the network via DHCP:
-# DHCP = true
-
-# to configure the network statically with ip 10.0.0.2/24 and gateway 10.0.0.1:
-# IP = "10.0.0.2"
-# NETMASK = "255.255.255.0"
-# GATEWAYS = "10.0.0.1"
-#
-# if none of DHCP || (IP && NETMASK && GATEWAYS) is set,
-# default static settings will be used.
-
-# to serve pages over https:
-# TLS = true
-# to make it work with FS=crunch, put the certificate in tls/tls/server.key and the private key in tls/tls/server.pem
-
-# to redirect all http requests to https://somewhereelse.org:
-# REDIRECT = https://somewhereelse.org
-# (redirect must be an http:// or https:// url)
-# if TLS is set but REDIRECT is not, the value of REDIRECT will be assumed to be https://$HOST , with the effect that all http requests will be redirected to https
-
+# FLAGS for the "mirage configure" command.
 FLAGS  ?=
 
 .PHONY: all configure build run clean
 
 all:
-	@echo "To build this website, look in the Makefile and set"
-	@echo "the appropriate variables (MODE, FS, NET, DHCP, REDIRECT, HOST, TLS)."
-	@echo "make configure && make depend && make build"
+	@echo "To build this website, first use \"make prepare\""
+	@echo "You can then build the mirage application in the src/ directory"
+	@echo "cd src && mirage configure && make"
+	@echo "For unikernel configuration option, do \"mirage configure --help\" in src/"
 
-configure:
+prepare:
 	cd stats && make depend
-	# the make depend in src will crunch the stats into the fs:
 	cd stats && make all
+
+configure: prepare
 	mirage configure -f src/config.ml $(FLAGS) -t $(MODE)
 
 depend:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ It provides information about the project as well as the blog and wiki.
 
 It also serves as a good first self-hosting test case.
 
+
+To build this website, first use `make prepare`
+You can then build the mirage application in the src/ directory:
+```
+cd src && mirage configure && make
+```
+
+For unikernel configuration options, use `mirage configure --help` in `src`.
+
 To update, send a pull request. When successfully merged, the Travis CI scripts,
 fetched from <https://github.com/ocaml/ocaml-travisci-skeleton/>, will cause the
 generated Xen unikernel to be committed back to the

--- a/src/config.ml
+++ b/src/config.ml
@@ -26,8 +26,8 @@ open Mirage
 
 let tls_key =
   let doc = Key.Arg.info
-      ~doc:"Enable serving the website over https."
-      ~env:"TLS" ["tls"]
+      ~doc:"Enable serving the website over https. Do not forget to put certificates in tls/"
+      ~docv:"BOOL" ~env:"TLS" ["tls"]
   in
   Key.(create "tls" Arg.(opt ~stage:`Configure bool false doc))
 
@@ -42,14 +42,15 @@ let pr_key =
 let host_key =
   let doc = Key.Arg.info
       ~doc:"Hostname of the unikernel."
-      ~env:"HOST" ["host"]
+      ~docv:"URL" ~env:"HOST" ["host"]
   in
   Key.(create "host" Arg.(opt string "localhost" doc))
 
 let redirect_key =
   let doc = Key.Arg.info
-      ~doc:"Where to redirect to."
-      ~env:"REDIRECT" ["redirect"]
+      ~doc:"Where to redirect to. Must start with http:// or https://. \
+            When tls is enabled, the default is https://$HOST, with the effect that all http requests will be redirected to https"
+      ~docv:"URL" ~env:"REDIRECT" ["redirect"]
   in
   Key.(create "redirect" Arg.(opt (some string) None doc))
 


### PR DESCRIPTION
This update the instructions inside the repository. 

[This webpage](https://mirage.io/wiki/mirage-www) still needs to be rewritten. I'm not sure what should be done exactly. I'm in favor of just asking people to look at `mirage configure --help`, since it will always be more up-to-date than whatever is written there. What's your opinion ?