### PR TITLE
fix src/config.ml so ocamlfind ocamldep succeeds with 4.01.0

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -54,7 +54,7 @@ let redirect_key =
   in
   Key.(create "redirect" Arg.(opt (some string) None doc))
 
-let keys = Key.[ abstract host_key ; abstract redirect_key ]
+let keys = Key.([ abstract host_key ; abstract redirect_key ])
 
 let fs_key = Key.(value @@ kv_ro ())
 let filesfs = generic_kv_ro ~key:fs_key "../files"


### PR DESCRIPTION
Previously:

ocamlfind ocamldep -package mirage -modules config.ml >
config.ml.depends
File "config.ml", line 57, characters 15-16:
Error: Syntax error
Command exited with code 2.

Now:

$ ocamlfind ocamldep -package mirage -modules
src/config.mlsrc/config.ml: Arg Key Mirage String Sys

Signed-off-by: Mindy Preston <mindy.preston@docker.com>