### PR TITLE
Minor fixes and clarifications to Hello World and Mirage WWW doc pages.

### DIFF
--- a/tmpl/wiki/hello-world.md
+++ b/tmpl/wiki/hello-world.md
@@ -712,9 +712,9 @@ the commonly available _netcat_ `nc(1)` utility. From a different console
 execute:
 
 ```
-$ echo -n hello udp world | nc -n4w1 -u 127.0.0.1 53
+$ echo -n hello udp world | nc -unw1 127.0.0.1 53
 [ 1 sec delay ]
-$ echo -n hello tcp world | nc -n4w1 127.0.0.1 8080
+$ echo -n hello tcp world | nc -nw1 127.0.0.1 8080
 ```
 
 On the first console you should now see (each line in red, green and finally
@@ -778,8 +778,8 @@ address we can then trigger the application logic with some network input from
 
 
 ```
-$ echo -n hello udp world | nc -n4 -u -w1 192.168.64.5 53
-$ echo -n hello tcp world | nc -n4 -w1 192.168.64.5 8080
+$ echo -n hello udp world | nc -unw1 192.168.64.5 53
+$ echo -n hello tcp world | nc -nw1 192.168.64.5 8080
 ```
 
 The original terminal reports the ARP transactions invoked by the stack, and
@@ -802,8 +802,10 @@ work on pre-Yosemite Mac OSX, but has not been tested on Yosemite where the new
 
 By default, if we do not use DHCP with a `direct` network stack, Mirage will
 configure the stack to use the `tap0` interface with an address of `10.0.0.2`.
-This requires the tuntap bridge to be configured after the unikernel starts to
-ensure we have a route to it. Thus:
+Verify that you have an existing `tap0` interface by reviewing `$ sudo ip
+link show`; if you do not, load the tuntap kernel module (`$ sudo modprobe tun`)
+and create a `tap0` interface owned by root (`$ sudo tunctl`). Bring `tap0` up
+using `$ sudo ifconfig tap0 10.0.0.1 up`, then:
 
 ```
 $ cd stackv4
@@ -821,11 +823,9 @@ Manager: configuration done
 IP address: 10.0.0.2
 ```
 
-Now in another terminal, configure `tap0` and you should then be able to ping
-the unikernel's interface:
+Now you should be able to ping the unikernel's interface:
 
 ```
-$ sudo ifconfig tap0 10.0.0.1 255.255.255.0 up
 $ ping 10.0.0.2
 PING 10.0.0.2 (10.0.0.2) 56(84) bytes of data.
 64 bytes from 10.0.0.2: icmp_seq=1 ttl=38 time=0.527 ms
@@ -849,8 +849,8 @@ Finally, you can then execute the same `nc(1)` commands as before (modulo the
 target IP address of course!) to interact with the running unikernel:
 
 ```
-$ echo -n hello udp world | nc -n4 -u -w1 10.0.0.2 53
-$ echo -n hello tcp world | nc -n4 -w1 10.0.0.2 8080
+$ echo -n hello udp world | nc -unw1 10.0.0.2 53
+$ echo -n hello tcp world | nc -nw1 10.0.0.2 8080
 ```
 
 And you will see the same output in the unikernel's terminal:

--- a/tmpl/wiki/mirage-www.md
+++ b/tmpl/wiki/mirage-www.md
@@ -67,9 +67,14 @@ The website will now be available on `http://localhost/`.
 ## Building the direct networking version
 
 Now you can build the Unix unikernel using the direct stack, via a similar
-procedure to the [hello world](/wiki/hello-world) examples.
-
-On Unix with a tuntap device:
+procedure to the [hello world](/wiki/hello-world) examples. As before,
+Mirage will configure the stack to use the
+[tap0 interface](http://en.wikipedia.org/wiki/TUN/TAP) with an address
+of `10.0.0.2/255.255.255.0`. Verify that you have an existing `tap0`
+interface by reviewing `$ sudo ip link show`; if you do not,
+load the tuntap kernel module (`$ sudo modprobe tun`)
+and create a `tap0` interface owned by root (`$ sudo tunctl`). Bring `tap0` up
+using `$ sudo ifconfig tap0 10.0.0.1 up`, then:
 
 ```
 $ cd src
@@ -78,13 +83,9 @@ $ make
 $ sudo ./mir-www
 ```
 
-This will open a [tap device](http://en.wikipedia.org/wiki/TUN/TAP) device and
-assign itself a default IP of `10.0.0.2`/`255.255.255.0`. You need to set up
-your routing so that you can see this IP by assigning an IP to the `tap0`
-interface in a separate terminal.
+You should now be able to ping the unikernel's interface:
 
 ```
-$ sudo ifconfig tap0 10.0.0.1 255.255.255.0
 $ ping 10.0.0.2
 ```
 


### PR DESCRIPTION
The examples using netcat assume the user is using netcat-openbsd
rather than netcat-traditional; the former allows the -4 flag to
force IPv4 address use only, the latter does not support the flag.
The -4 flag is not needed here and thus has been removed
from all examples. The various flags have been consolidated as well.

The two sections regarding use of Mirage with static IP addresses assumes
the user has an existing tap0 interface, which may not be the case.
Additionally, on both pages, the command given to bring tap0 up does not work on
recent versions of ifconfig, and on the mirage-www page, is missing the
"up" argument at the end. To remedy this, statements explaining
how to set up tap0 have been added, and the commands to bring tap0
up have been updated/corrected and moved up to ensure they are executed prior to
the start of the unikernel.