### PR TITLE
Remove API link from navbar.

### DIFF
--- a/src/pages.ml
+++ b/src/pages.ml
@@ -55,7 +55,6 @@ module Global = struct
     tag "ul" ~cls:"left" (list [
       tag "li" (a ~href:(uri "/blog/") (string "Blog"));
       tag "li" (a ~href:(uri "/docs/") (string "Docs"));
-      tag "li" (a ~href:(uri "http://mirage.github.io/") (string "API"));
       tag "li" (a ~href:(uri "/releases/") (string "Changes"));
       tag "li"~cls:"has-dropdown" (list [
           a ~href:(uri "/community/") (string "Community");


### PR DESCRIPTION
The API link in the navbar goes to [a very old Github Pages automatically generated repository](https://github.com/mirage/mirage.github.io).  Until we can figure out a nice way to automatically generate this content, remove the link so users aren't directed to outdated documentation.