### PR TITLE
move myself to core team

### DIFF
--- a/tmpl/about-community.md
+++ b/tmpl/about-community.md
@@ -5,7 +5,6 @@
 * *David Kaloper*, [github.com](https://github.com/pqwy)
 * *Steven Hand*, [cl.cam.ac.uk](http://www.cl.cam.ac.uk/~smh22/)
 * *Jon Ludlam*, Citrix Systems R&D, [jon.recoil.org](http://jon.recoil.org/)
-* *Hannes Mehnert*, [github.com](https://github.com/hannesm)
 * *Raphael Proust*, University of Cambridge, [cl.cam.ac.uk](http://www.cl.cam.ac.uk/~rp452/)
 * *Haris Rotsos*, University of Cambridge, [cl.cam.ac.uk](http://www.cl.cam.ac.uk/~cr409/)
 * *David Sheets*, University of Cambridge, [github.com](https://github.com/dsheets)

--- a/tmpl/about.md
+++ b/tmpl/about.md
@@ -10,4 +10,5 @@ at our respective institutions.
 * **[Richard Mortier](http://www.cs.nott.ac.uk/~rmm/)**, University of Nottingham
 * **[Thomas Leonard](http://roscidus.com/blog/)**, University of Cambridge
 * **[Mindy Preston](http://www.somerandomidiot.com)**, Docker
+* **[Hannes Mehnert](https://hannes.nqsb.io)**, University of Cambridge
 * Community Manager: **[Amir Chaudhry](http://amirchaudhry.com/)**, University of Cambridge


### PR DESCRIPTION
quoting @avsm from <3D7C4456-4330-431C-9BD2-16693AF3A817@recoil.org> (7th March 2016): `and to state the obvious, we should add hannes to the core mirage team :-)`

@avsm