### PR TITLE
dispatch_tls no longer takes a console argument

### DIFF
--- a/src/dispatch_tls.mli
+++ b/src/dispatch_tls.mli
@@ -20,7 +20,6 @@
 module Make
     (S: V1_LWT.STACKV4)
     (KEYS: V1_LWT.KV_RO)
-    (C: V1_LWT.CONSOLE)
     (FS: V1_LWT.KV_RO)
     (TMPL: V1_LWT.KV_RO)
     (Clock : V1.CLOCK) :
@@ -28,6 +27,6 @@ sig
 
   val start:
     S.t -> KEYS.t ->
-    C.t -> FS.t -> TMPL.t -> unit -> unit -> unit Lwt.t
+    FS.t -> TMPL.t -> unit -> unit -> unit Lwt.t
     (** The HTTP server's start function. *)
 end


### PR DESCRIPTION
The changeset in #502 was incomplete (as seen by https://travis-ci.org/mirage/mirage-www/jobs/181020546 ) and results in a broken deployment build (and indeed any build that attempts to build with `--tls true`).  Please don't merge this PR unless tests are passing.