### PR TITLE
Refresh installation instructions

### DIFF
--- a/tmpl/wiki/install.md
+++ b/tmpl/wiki/install.md
@@ -1,12 +1,20 @@
-MirageOS consists of a set of OCaml libraries that link with a runtime to form either a standalone Xen operating system or a normal UNIX binary. These libraries are managed via the [OPAM](https://opam.ocaml.org) tool. After describing MirageOS's system requirements, we will introduce the basics of OPAM and setting up for MirageOS.
+MirageOS consists of a set of OCaml libraries that link with a runtime to form either a standalone [unikernel](https://en.wikipedia.org/wiki/Unikernel) or a normal UNIX binary. These libraries are managed via the [OPAM](https://opam.ocaml.org) tool. After describing MirageOS's system requirements, we will introduce the basics of OPAM and setting up for MirageOS.
 
 ## Requirements
 
-MirageOS has been tested on ArchLinux, Debian Wheezy/Jessie, Ubuntu 14.04/16.10, CentOS 6/7 and MacOS X 10.10+. To compile the Xen backend, you *must* have a 64-bit Linux host. 32-bit is not supported at this time.
+MirageOS has been tested on many modern Linux distributions, MacOS X 10.10+ and FreeBSD 11+.
 
-### MacOS X
+You will need OPAM 1.2.2 or later and OCaml 4.03.0 or later.
 
-* __10.10__: No special requirements beyond Homebrew or MacPorts to get OCaml.
+Some backends have specific requirements for the host system:
+
+* __ukvm__: To compile the `ukvm` backend you *must* have a Linux host.
+* __virtio__: To compile the `virtio` backend you *must* have a Linux or FreeBSD host.
+* __xen__: To compile the `xen` backend, you *must* have a 64-bit Linux host. 32-bit is not supported at this time.
+
+### MacOS X-specific notes
+
+* __10.10__: No special requirements beyond Homebrew or MacPorts to get OCaml and OPAM.
 * __10.9 or lower__: You will also need the [tuntap](http://tuntaposx.sourceforge.net/) kernel module if you want to use the MirageOS network stack from userspace.  Note that we do not test older versions of OSX beyond 10.10.
 
 If you are using Homebrew, run
@@ -15,7 +23,7 @@ If you are using Homebrew, run
     opam init
     opam install mirage
 
-### Ubuntu
+### Linux-specific notes
 
 #### Ubuntu 16.04 (Xenial) or higher
 
@@ -36,10 +44,6 @@ The version of OPAM in older Ubuntus is not high enough to run Mirage (which req
     opam init
     opam install mirage
 
-Also note that the `mirage` configuration and deployment tool relies on the `xl` Xen toolstack to run Xen virtual machines.  Older Ubuntus may use the `xm` toolstack, so you will need to change it.
-
-### Debian 
-
 #### Debian Stable (Jessie)
 
 Debian Jessie only packages OPAM 1.2.0, but Mirage needs OPAM 1.2.2 or higher.  You can use [0install](http://0install.net) to get the right version of OPAM:
@@ -58,7 +62,11 @@ These distributions include everything you need to run Mirage in the base distri
     sudo apt-get install ocaml ocaml-native-compilers camlp4-extra opam
     opam init
     opam install mirage
-  
+
+### FreeBSD-specific notes
+
+You will need ports or `pkg` set up. To install OPAM use the `ocaml-opam` port/package. FreeBSD currently packages OCaml 4.02.3, so you will need to install a newer compiler using OPAM.
+
 ## MirageOS Package Management with OPAM
 
 We use [OPAM](https://opam.ocaml.org) to manage OCaml compiler and library installations. It tracks library versions across upgrades and will recompile dependencies automatically if they get out of date. Please refer to OPAM [documentation](https://opam.ocaml.org) if you want to know more, but we will cover the basics to get you started here. There is a [Quick Install Guide](http://opam.ocaml.org/doc/Install.html) if the above instructions don't cover your operating system.
@@ -76,11 +84,11 @@ After installation, `opam update -u` refreshes the package list and recompiles p
     # list of your remotes, which should include opam.ocaml.org
     $ opam remote
 
-Next, make sure you have at least **OCaml 4.02.3 or higher** as your active compiler. This is generally the case on MacOS X, though Debian only has it in the *testing* distribution at present. But don't worry: if your compiler is out of date, just run `opam switch` to have it locally install the right version for you.
+Next, make sure you have at least **OCaml 4.03.0 or higher** as your active compiler. This is generally the case on MacOS X, though Debian only has it in the *testing* distribution at present. But don't worry: if your compiler is out of date, just run `opam switch` to have it locally install the right version for you.
 
     $ ocaml -version
-    # if it is not 4.02.3 or higher, then run this
-    $ opam switch 4.02.3
+    # if it is not 4.03.0 or higher, then run this
+    $ opam switch 4.03.0
 
 Once you've got the right version, set up your shell environment to point to the current compiler switch.
 
@@ -103,7 +111,4 @@ Finally, install the MirageOS command-line tool.
     $ opam install mirage
     $ mirage --help
 
-This will install [Mirage](https://github.com/mirage/mirage)!
-If you're upgrading from an older beta installation of MirageOS, then be sure that you have at least 2.9.0.  You can verify this by checking that the version number in the manual page from `mirage --help` is at least 2.9.0 (as of the time of writing this page).
-
-That's it. You now have everything required to start developing MirageOS unikernels that will run either as POSIX processes or as Xen VMs using the MirageOS network stack. Next, why not try [building a MirageOS *hello world*](/wiki/hello-world)?
+That's it. You now have everything required to start developing MirageOS unikernels that will run either as POSIX processes or as standalone unikernels. Next, why not try [building a MirageOS *hello world*](/wiki/hello-world)?


### PR DESCRIPTION
- Remove Xen-specific references/replace with "standalone unikernel"
where appropriate
- Remove list of "Linux distributions we test on", replace with generic
"many modern Linux distributions"
- Add backend-specific requirements for Solo5 backends
- Add stub with FreeBSD instructions
- Remove paragraph about upgrading from beta which seems out of date,
not sure if it needs to be here for new users

@yomimono / @avsm Please review, this is a minimal refresh of the installation instructions.

Are we still recommending `0install` as "the way to get opam 1.2.2 on Debian stable"? (/cc @talex5)