### PR TITLE
remove google analytics

### DIFF
--- a/tmpl/main.html
+++ b/tmpl/main.html
@@ -3,17 +3,6 @@
 <head>
   <title>openmirage :: $TITLE$</title>
   <link rel="stylesheet" type="text/css" href="/styles/index.css"/>
-  <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-19610168-1']);
-    _gaq.push(['_trackPageview']);
-
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
-  </script>
   $EXTRA_HEADER$
 </head>
 


### PR DESCRIPTION
I discovered the other day (via https://sitestacks.com/mirage.io) that mirage.io still uses google analytics.  I've not heard of any "results" or changes to the website due to analytics in the past 4 years (neither do I know who has access and who is looking into the data).  While google analytics may be justified for commercial websites where you want to optimise for your (potential) customers, I don't think an open source project whose goal is to redesign nowadays computing infrastructure should use such a tracking service (NB related projects, esp. such privacy related as nymote.org should avoid this as well).

I'm happy to further discuss alternatives if you think analytics is needed on this website.  In my opinion it should at least be something self-hosted and open for anyone to access (e.g. https://piwik.org/).  We should furthermore ensure that individual user data (such as IP address etc.) is properly anonymised.

EDIT: git history shows me google-analytics was added 7 years ago https://github.com/mirage/mirage-www/commit/abae6f9f52f96580360e5258c39128d95d75e7df - but I'm only following this project closely since 4 years.