### PR TITLE
Update info for Amir

### DIFF
--- a/tmpl/about.md
+++ b/tmpl/about.md
@@ -13,4 +13,4 @@ Lexicographically ordered by last name:
 * **[Richard Mortier](http://mort.io/)**, University of Cambridge & Docker
 * **[Mindy Preston](http://www.somerandomidiot.com)**
 * **[David Scott](http://dave.recoil.org)**, Docker
-* Community Manager: **[Amir Chaudhry](http://amirchaudhry.com/)**, Docker
+* **[Amir Chaudhry](http://amirchaudhry.com/)**


### PR DESCRIPTION
Removed affiliation and also dropped the title.
That particular function is spread across a number
of folks, so it's been outdated for some time.