### PR TITLE
Revert "travis: don't pin mirage"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     --ipv4-gateway 46.43.42.129 --tls true
     --secrets-kv_ro fat --host mirage.io"
   global:
+  - PINS=mirage:3.0.7
   - UPDATE_GCC_BINUTILS=1
   - SRC_DIR=./src
   - secure: PUu3+Enupf9jcIPD/hs5b6zrNuJagTDXJGtYfSUIFvzevSXZzs6mXPu8L2vvAQbQ8ig/8VLToa44vUTG9OEy9SxXrR6yTQGfj4YxJ5BXKHwhYMTBXnR1e+S1gA4a5tilMa7M/a0hWa1rORv3diMIK3dihjc1m6VzpCK/4vly7KU=


### PR DESCRIPTION
This reverts commit 9b75e742519602ef3c53487da037cb3e76893591.

This should "fix" the current deployment issue of https://mirage.io. See #621  /cc @hannesm 