### PR TITLE
reyn.ir -> reynir.dk

### DIFF
--- a/tmpl/blog/2017-march-hackathon-roundup.md
+++ b/tmpl/blog/2017-march-hackathon-roundup.md
@@ -5,7 +5,7 @@ This March, 34 people from around the world gathered in Marrakech for a spring M
 
 In addition to the reports below, you can find other information online:
 - the daily [tweets about the event](http://ocamllabs.io/events/2017/03/06/MirageHackUpdates.html), including sophisticated "paper slides"
-- [Olle Jonsson](http://ollehost.dk/blog/2017/03/17/travel-report-mirageos-hack-retreat-in-marrakesh-2017/) and [Reynir Björnsson](https://reyn.ir/posts/2017-03-20-11-27-Marrakech%202017.html) wrote up their experiences on their personal sites.
+- [Olle Jonsson](http://ollehost.dk/blog/2017/03/17/travel-report-mirageos-hack-retreat-in-marrakesh-2017/) and [Reynir Björnsson](https://reynir.dk/posts/2017-03-20-11-27-Marrakech%202017.html) wrote up their experiences on their personal sites.
 
 ## Hannes Mehnert
 

--- a/tmpl/blog/2017-winter-hackathon-roundup.md
+++ b/tmpl/blog/2017-winter-hackathon-roundup.md
@@ -122,7 +122,7 @@ and how they say: failure the best teacher is.
 ## Reynir Björnsson
 
 For the second time this year (and ever) I went to Marrakech to participate in the MirageOS hack retreat / unconference.
-I wrote about my [previous trip](http://reyn.ir/posts/2017-03-20-11-27-Marrakech%202017.html).
+I wrote about my [previous trip](http://reynir.dk/posts/2017-03-20-11-27-Marrakech%202017.html).
 
 ### The walk from the airport
 


### PR DESCRIPTION
The domain reyn.ir has become unavailable due to sillyness around US
sanctions against Iran and a lost password.