### PR TITLE
add MSA01.md

### DIFF
--- a/tmpl/advisories/01.txt.asc
+++ b/tmpl/advisories/01.txt.asc
@@ -1,0 +1,110 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+## MirageOS Security Advisory 01 - memory disclosure in mirage-net-xen
+
+- - Module:       netchannel
+- - Announced:    2019-03-21
+- - Credits:      Thomas Leonard, Hannes Mehnert, Mindy Preston
+- - Affects:      netchannel = 1.10.0
+- - Corrected:    2019-03-20 1.10.1 release
+
+For general information regarding MirageOS Security Advisories,
+please visit [https://mirage.io/security](https://mirage.io/security).
+
+### Background
+
+MirageOS is a library operating system using cooperative multitasking, which can
+be executed as a guest of the Xen hypervisor.  Virtual devices, such as a
+network device, share memory between MirageOS and the hypervisor.  To maintain 
+adequate performance, the virtual device managing network communication between 
+MirageOS and the Xen hypervisor maintains a shared pool of pages and reuses 
+them for write requests.
+
+### Problem Description
+
+In version 1.10.0 of netchannel, the API for handling network requests 
+changed to provide higher-level network code with an interface for writing into 
+memory directly.  As part of this change, code paths which exposed memory taken 
+from the shared page pool did not ensure that previous data had been cleared 
+from the buffer.  This error resulted in memory which the user did not 
+overwrite staying resident in the buffer, and potentially being sent as part of 
+unrelated network communication.
+
+The mirage-tcpip library, which provides interfaces for higher-level operations 
+like IPv4 and TCP header writes, assumes that buffers into which it writes have 
+been zeroed, and therefore may not explicitly write some fields which are always 
+zero.  As a result, some packets written with netchannel v1.10.0 which were 
+passed to mirage-tcpip with nonzero data will have incorrect checksums 
+calculated and will be discarded by the receiver.
+
+### Impact
+
+This issue discloses memory intended for another recipient and corrupts packets.
+Only version 1.10.0 of netchannel is affected.  Version 1.10.1 fixes this issue.
+
+Version 1.10.0 was available for less than one month and many upstream users
+had not yet updated their own API calls to use it.  In particular, no version of
+qubes-mirage-firewall or its dependency mirage-nat compatible with version
+1.10.0 was released.
+
+### Workaround
+
+No workaround is available.
+
+### Solution
+
+Transmitting corrupt data and disclosing memory is fixed in version 1.10.1.
+
+The recommended way to upgrade is:
+```bash
+opam update
+opam upgrade netchannel
+```
+
+Or, explicitly:
+```bash
+opam upgrade
+opam reinstall netchannel=1.10.1
+```
+
+Affected releases (version 1.10.0 of netchannel and mirage-net-xen) have been marked uninstallable in the opam repository.
+
+### Correction details
+
+The following list contains the correction revision numbers for each
+affected branch.
+
+Memory disclosure on transmit:
+
+master: [6c7a13a5dae0f58dcc0653206a73fa3d8174b6d2](https://github.com/mirage/mirage-net-xen/commit/6c7a13a5dae0f58dcc0653206a73fa3d8174b6d2)
+
+1.10.0: [bd0382eabe17d0824c8ba854ec935d8a2e5f7489](https://github.com/mirage/mirage-net-xen/commit/bd0382eabe17d0824c8ba854ec935d8a2e5f7489)
+
+### References
+
+[netchannel](https://github.com/mirage/mirage-net-xen)
+
+You can find the latest version of this advisory online at
+[https://mirage.io/blog/MSA01](https://mirage.io/blog/MSA01).
+
+This advisory is signed using OpenPGP, you can verify the signature
+by downloading our public key from a keyserver (`gpg --recv-key 4A732D757C0EDA74`),
+downloading the raw markdown source of this advisory from [GitHub](https://raw.githubusercontent.com/mirage/mirage-www/master/tmpl/advisories/01.txt.asc)
+and executing `gpg --verify 01.txt.asc`.
+-----BEGIN PGP SIGNATURE-----
+
+iQIcBAEBAgAGBQJck8mYAAoJEEpzLXV8Dtp03RMP/jRiGkXBixZJCRKXXOuGwKhN
+lkbjQX9GN+cBoDB74sBLL5lefCYZzFck9Ouk3YapX+7Uj+adFJc+XQUxy7aB2/Pl
+3s6bdImRrNFmGU6rTT5icC6SIksNHe5D8Nv/MxL/yeQp+UOs3v0pFh2wIkgmM4+K
+QxMi3xpN2lRGYFqOHUPouAIDnhBHjg40Aeg1xT0V4H+AQLtg40+B8lRZTzzUVOkk
+yIyBViil6Okz1V2PWWpJnfakGB6pJqCv2dt4fGEZGnnmdKXRucTwIb/fStB7y03e
+E7HGJiHZqEJrsJam/9K/vaqETfxH3JrHbeKdiYn5kL0tapK6Dl0O71T5cBykIxZd
+slcmuuUCUVgaVZfsug7V5rtisFbLkJM3LFNfwRZRsoJaMyNuCqcm03ENJRFCI4cg
+OAQ6f42dfmNKI2QTOxunMkCw2/CT3d6Vru9RELo549SEeCvsGK2J0PzGcw2X2d3l
+SQB4NdA4bXUmDyjAjmdqh8VrCfSok0YrF3FSoQR151lQpZSs9ziWOG+U9RQ1+TBf
+M5HzMMmIARR261WzZ/5kdieMeWwu87DltD0ZsrSOxls+UYwSdi05oJm1Sh3zT/yL
+4VgmM0BX0/oRdCGipfmRB+PUOaSLgljoVfu+/xpm1p9hzQIgPaPkDT4Ae8l5BwXc
+BZbCK/4TktwU4S8Eg+92
+=LrX+
+-----END PGP SIGNATURE-----

--- a/tmpl/blog/MSA01.md
+++ b/tmpl/blog/MSA01.md
@@ -1,0 +1,91 @@
+## MirageOS Security Advisory 01 - memory disclosure in mirage-net-xen
+
+- Module:       netchannel
+- Announced:    2019-03-21
+- Credits:      Thomas Leonard, Hannes Mehnert, Mindy Preston
+- Affects:      netchannel = 1.10.0
+- Corrected:    2019-03-20 1.10.1 release
+
+For general information regarding MirageOS Security Advisories,
+please visit [https://mirage.io/security](https://mirage.io/security).
+
+### Background
+
+MirageOS is a library operating system using cooperative multitasking, which can
+be executed as a guest of the Xen hypervisor.  Virtual devices, such as a
+network device, share memory between MirageOS and the hypervisor.  To maintain 
+adequate performance, the virtual device managing network communication between 
+MirageOS and the Xen hypervisor maintains a shared pool of pages and reuses 
+them for write requests.
+
+### Problem Description
+
+In version 1.10.0 of netchannel, the API for handling network requests 
+changed to provide higher-level network code with an interface for writing into 
+memory directly.  As part of this change, code paths which exposed memory taken 
+from the shared page pool did not ensure that previous data had been cleared 
+from the buffer.  This error resulted in memory which the user did not 
+overwrite staying resident in the buffer, and potentially being sent as part of 
+unrelated network communication.
+
+The mirage-tcpip library, which provides interfaces for higher-level operations 
+like IPv4 and TCP header writes, assumes that buffers into which it writes have 
+been zeroed, and therefore may not explicitly write some fields which are always 
+zero.  As a result, some packets written with netchannel v1.10.0 which were 
+passed to mirage-tcpip with nonzero data will have incorrect checksums 
+calculated and will be discarded by the receiver.
+
+### Impact
+
+This issue discloses memory intended for another recipient and corrupts packets.
+Only version 1.10.0 of netchannel is affected.  Version 1.10.1 fixes this issue.
+
+Version 1.10.0 was available for less than one month and many upstream users
+had not yet updated their own API calls to use it.  In particular, no version of
+qubes-mirage-firewall or its dependency mirage-nat compatible with version
+1.10.0 was released.
+
+### Workaround
+
+No workaround is available.
+
+### Solution
+
+Transmitting corrupt data and disclosing memory is fixed in version 1.10.1.
+
+The recommended way to upgrade is:
+```bash
+opam update
+opam upgrade netchannel
+```
+
+Or, explicitly:
+```bash
+opam upgrade
+opam reinstall netchannel=1.10.1
+```
+
+Affected releases (version 1.10.0 of netchannel and mirage-net-xen) have been marked uninstallable in the opam repository.
+
+### Correction details
+
+The following list contains the correction revision numbers for each
+affected branch.
+
+Memory disclosure on transmit:
+
+master: [6c7a13a5dae0f58dcc0653206a73fa3d8174b6d2](https://github.com/mirage/mirage-net-xen/commit/6c7a13a5dae0f58dcc0653206a73fa3d8174b6d2)
+
+1.10.0: [bd0382eabe17d0824c8ba854ec935d8a2e5f7489](https://github.com/mirage/mirage-net-xen/commit/bd0382eabe17d0824c8ba854ec935d8a2e5f7489)
+
+### References
+
+[netchannel](https://github.com/mirage/mirage-net-xen)
+
+You can find the latest version of this advisory online at
+[https://mirage.io/blog/MSA01](https://mirage.io/blog/MSA01).
+
+This advisory is signed using OpenPGP, you can verify the signature
+by downloading our public key from a keyserver (`gpg --recv-key 4A732D757C0EDA74`),
+downloading the raw markdown source of this advisory from [GitHub](https://raw.githubusercontent.com/mirage/mirage-www/master/tmpl/advisories/01.txt.asc)
+and executing `gpg --verify 01.txt.asc`.

--- a/tmpl/security.md
+++ b/tmpl/security.md
@@ -8,6 +8,7 @@ team will respond and we will take it from there.
 
 A OpenPGP key is [available from the keyservers](http://keys.mayfirst.org/pks/lookup?op=get&fingerprint=on&search=0x4A732D757C0EDA74), its fingerprint is `23B2 822C 89A9 EC73 C7DF  0748 4A73 2D75 7C0E DA74`.
 
+- [21st March 2019: MSA01 netchannel=1.10.0](https://mirage.io/blog/MSA01)
 - [3rd May 2016: MSA00 mirage-net-xen<1.4.2](https://mirage.io/blog/MSA00)
 
 [issues]: https://github.com/mirage/mirage/issues


### PR DESCRIPTION
Add Mirage security announcement 01, memory disclosure in mirage-net-xen/netchannel version 1.10.0, advising users to upgrade to version 1.10.1.