### PR TITLE
rename MSA 02 from 02.md.asc to 02.txt.asc, fix instructions, link from security.md to MSA02 (#640)

### DIFF
--- a/tmpl/advisories/02.txt.asc
+++ b/tmpl/advisories/02.txt.asc
@@ -1,5 +1,5 @@
 -----BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA1
+Hash: SHA384
 
 ## MirageOS Security Advisory 02 - grant unshare vulnerability in mirage-xen
 
@@ -104,24 +104,25 @@ by downloading our public key from a keyserver (`gpg --recv-key
 4A732D757C0EDA74`),
 downloading the raw markdown source of this advisory from
 [GitHub](https://raw.githubusercontent.com/mirage/mirage-www/master/tmpl/advisories/02.txt.asc)
-and executing `gpg --verify 02.md.asc`.
+and executing `gpg --verify 02.txt.asc`.
 
 [gnttab_end_access]: https://github.com/mirage/mini-os/blob/94cb25eb73e58e5c825c1ad5f6cf3d2647603a50/gnttab.c#L98
 [stub_gntshr_end_access]: https://github.com/mirage/mirage-xen/blob/v3.2.0/bindings/gnttab_stubs.c#L227
 [new grant API]: https://github.com/mirage/mirage-xen/pull/9
 -----BEGIN PGP SIGNATURE-----
 
-iQIcBAEBAgAGBQJcwnZyAAoJEEpzLXV8Dtp0dSoP/0BCK1AlXvD3w/AqmVpYzfuQ
-QK1q/Qsio5QTe7blcOAmKjCXAeWU50EDCdBo6RgvbrNd1fGwEaGfL13cJEybVzWP
-IZ+0mkLcXLzVnN63TKOAyvRlsOOnBPJVGtjzD6mivDPYWyYttRO4FKXrjgFMaOmp
-VXlIZMXbceIAZ3lwFjk1siyYEjGTTDEeXJb2WSELv/o9K/HaeqvsTzuQUWDYc7Cr
-hiRKp7wMVR+47UgF48UqzpaxF0sxF28Wq9KbTkm1ZKjFkNxpGlHndX9q2hSRghF7
-xCNuOlF0rKA5N3/xAwXpzLILAOLojfOnmAF1Wr4uH2GoqbVfAUiLPe87p3hQ9+3o
-J6KBvSqShwq8Y5wPcSaY1e0+g+B2HwyaXTbWU5ypsfx7SM3DX5kEvVO5P/KnkVD2
-sICPAmtY1PmUa6+NQu3T7a6SKuTBU7hpwMYPvhbjKrDpYAKitsrGva8hPuPcMYIs
-Y8vDeHikTBNi3B0xPMSSz5b9uAXel6JxVu/Z+KKnBO1Zgq6VdiIDhoyPlJ70276f
-Khj7i1dagnBPoVfNA1vQMWTEzEahE5OFCTSNzqsI5wdT1h/rhFexYkYHMK2/K7Xp
-sWIhzUNTkoQavaMk3WwpavbV2ij3twIJNUuyaAQCnJIvUoDRq472zaSy6rlQpAj6
-GV65MNh4xKldzLw/GfDb
-=jWaK
+iQJHBAEBCQAxFiEEI7KCLImp7HPH3wdISnMtdXwO2nQFAlzC1n4THHNlY3VyaXR5
+QG1pcmFnZS5pbwAKCRBKcy11fA7adIxSD/0QRVmLfpI3y12hoUShmWOtwyON3+1d
+KKj93QqHMKVZWTzQgpeAoCZ38qjgvDGW4fJDWtYPghtPgZ8K36huGmRwgbsUy6XL
+TjXMOOqN67bb7fX4XX/sEXje4vblarbt8ql7N37aODuEBfjuzAxPtEHEcW5RNzs/
+NReDgUsMzEx5VjBK+SbAG7cJg8QusdjIBmrmB70gJzItMsiTkD0KlpT5L1930CO5
+PPfSMidVH3piPjeNErJ+odIs2/pkH/kSTBnEt5M1AQKkTfWcmzhzRU/U1HsF0wyc
+PyWqVgc/ZqnSewealdYI4cpzyMlHuLXXO7STjVzx1FD9KNY9YT90f2Ev56JTZFjV
+FTpxTspkivCE/r+/ypm8ca0adQZrlg5mLQOiYpK6ZmfBqf1Ti3QIPhyjP8mfxYuh
+JSk59gtCFhyyXepDQggjzyPXgQWt7pebng+LOpknHV/frCX5vMHHNOmZoiJGnRQe
+o0nm1IQvH2dr2+5CYQ9G2J9tfnrvCHbBfR99ShGqSqb9VZpUZMSfR6jvuZQX4aRK
+ykcuW/wtBsNREc5LvFtTMI9+FOyegTPw64m7fmI1HlUO45k5VnJRy3tW4Q046ome
+XhbSsQQrOZp9Y6HnY6lqOk2Hq5meR4M2HLWUkYffgU9YfYWgyJF4kTsAsKLJ8e9b
+iyFvF8Llnx/P+Q==
+=W58C
 -----END PGP SIGNATURE-----

--- a/tmpl/blog/MSA02.md
+++ b/tmpl/blog/MSA02.md
@@ -101,7 +101,7 @@ by downloading our public key from a keyserver (`gpg --recv-key
 4A732D757C0EDA74`),
 downloading the raw markdown source of this advisory from
 [GitHub](https://raw.githubusercontent.com/mirage/mirage-www/master/tmpl/advisories/02.txt.asc)
-and executing `gpg --verify 02.md.asc`.
+and executing `gpg --verify 02.txt.asc`.
 
 [gnttab_end_access]: https://github.com/mirage/mini-os/blob/94cb25eb73e58e5c825c1ad5f6cf3d2647603a50/gnttab.c#L98
 [stub_gntshr_end_access]: https://github.com/mirage/mirage-xen/blob/v3.2.0/bindings/gnttab_stubs.c#L227

--- a/tmpl/security.md
+++ b/tmpl/security.md
@@ -8,6 +8,7 @@ team will respond and we will take it from there.
 
 A OpenPGP key is [available from the keyservers](http://keys.mayfirst.org/pks/lookup?op=get&fingerprint=on&search=0x4A732D757C0EDA74), its fingerprint is `23B2 822C 89A9 EC73 C7DF  0748 4A73 2D75 7C0E DA74`.
 
+- [26th April 2019: MSA02 mirage-xen<3.3.0](https://mirage.io/blog/MSA02)
 - [21st March 2019: MSA01 netchannel=1.10.0](https://mirage.io/blog/MSA01)
 - [3rd May 2016: MSA00 mirage-net-xen<1.4.2](https://mirage.io/blog/MSA00)
 


### PR DESCRIPTION
hello,

while looking at #640, I saw that it is 02.md.asc, which refers to "download 02.txt.asc" and `gpg -verify 02.md.asc` (i.e. slightly inconsistent).

to unify the advisories, I renamed 02.md.asc to 02.txt.asc, fixed the content (thus the new signature), and embedded #640 (link from security page) by @talex5

/cc @yomimono 