### PR TITLE
Improve Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@ Dockerfile
 **/_build
 .git
 **/*.native
+**/*.xen
+**/*.hvt
 src/Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ocaml/opam2:alpine-3.10-ocaml-4.09
+FROM ocurrent/opam:alpine-3.10-ocaml-4.09
 RUN opam depext -ui mirage
 RUN mkdir -p /home/opam/www/src
 WORKDIR /home/opam/www/src
 COPY --chown=opam:root src/config.ml /home/opam/www/src/
-RUN opam config exec -- mirage configure -t unix
+ARG TARGET=unix
+RUN opam config exec -- mirage configure -t $TARGET
 RUN make depend
 COPY --chown=opam:root . /home/opam/www
-RUN opam config exec -- mirage configure -t unix
+RUN opam config exec -- mirage configure -t $TARGET
 RUN opam config exec -- make
-USER root
-ENTRYPOINT ["/home/opam/www/src/main.native"]
+RUN if [ $TARGET = hvt ]; then sudo cp www.$TARGET /unikernel.$TARGET; fi

--- a/README.md
+++ b/README.md
@@ -8,12 +8,28 @@ It provides information about the project as well as the blog and wiki.
 
 It also serves as a good first self-hosting test case.
 
+### Building with Docker
+
+The easiest way to get started is to build using Docker:
+
+```
+docker build -t mirage-www .
+docker run --rm -it --init -p 80:8080 mirage-www ./www --http-port 8080
+```
+
+Then browse to <http://127.0.0.1/>.
+
+You can build for other targets with e.g. `docker build --build-arg TARGET=hvt ...`.
+
+### Building without Docker
 
 To build this website, first use `make prepare`
 You can then build the mirage application in the src/ directory:
 ```
 cd src && mirage configure && make
 ```
+
+### Configuration
 
 For unikernel configuration options, use `mirage configure --help` in `src`.
 


### PR DESCRIPTION
- Explain how to build with Docker.
- Extend Dockerfile to allow building for other targets.
- Use the (much smaller) OCurrent base image.

Fixes #666.

I also removed the `ENTRYPOINT`, as it only works for Unix and makes it difficult for people to play around with the image interactively. When building for hvt, it now copies the image as `/unikernel.hvt`, which makes things easier for automatic deployment tools.