### PR TITLE
Mirageos.org deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ RUN mkdir -p /home/opam/www/src
 WORKDIR /home/opam/www/src
 COPY --chown=opam:root src/config.ml /home/opam/www/src/
 ARG TARGET=unix
-RUN opam config exec -- mirage configure -t $TARGET
+ARG EXTRA_FLAGS=
+RUN opam config exec -- mirage configure -t $TARGET $EXTRA_FLAGS
 RUN make depend
 COPY --chown=opam:root . /home/opam/www
-RUN opam config exec -- mirage configure -t $TARGET
+RUN opam config exec -- mirage configure -t $TARGET $EXTRA_FLAGS
 RUN opam config exec -- make
 RUN if [ $TARGET = hvt ]; then sudo cp www.$TARGET /unikernel.$TARGET; fi

--- a/src/config.ml
+++ b/src/config.ml
@@ -52,7 +52,6 @@ let pr_key =
   in
   Key.(create "pr" Arg.(opt ~stage:`Configure (some int) None doc))
 
-
 let host_key =
   let doc = Key.Arg.info
       ~doc:"Hostname of the unikernel."
@@ -84,10 +83,15 @@ let key_seed =
   let doc = Key.Arg.info ~doc:"certificate key seed" ["key-seed"] in
   Key.(create "key-seed" Arg.(required string doc))
 
+let additional_hostnames =
+  let doc = Key.Arg.info ~doc:"Additional names (used for certificates)" ["additional-hostname"] in
+  Key.(create "additional-hostnames" Arg.(opt (list string) [] doc))
+
 let keys = Key.([ abstract host_key ; abstract redirect_key ;
                   abstract http_port ; abstract https_port ;
                   abstract dns_key ; abstract dns_server ;
                   abstract dns_port ; abstract key_seed ;
+                  abstract additional_hostnames ;
                 ])
 
 let fs_key = Key.(value @@ kv_ro ())

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -17,8 +17,8 @@
 open Lwt.Infix
 
 module Make
+    (R: Mirage_random.S)
     (S: Mirage_stack.V4)
-    (KEYS: Mirage_kv.RO)
     (FS: Mirage_kv.RO)
     (TMPL: Mirage_kv.RO)
     (Clock : Mirage_clock.PCLOCK)
@@ -29,13 +29,14 @@ module Make
 
   module TCP  = S.TCPV4
   module TLS  = Tls_mirage.Make (TCP)
-  module X509 = Tls_mirage.X509 (KEYS) (Clock)
 
   module Http  = Cohttp_mirage.Server(TCP)
   module Https = Cohttp_mirage.Server(TLS)
 
   module D  = Dispatch.Make(Http)(FS)(TMPL)(Clock)
   module DS = Dispatch.Make(Https)(FS)(TMPL)(Clock)
+
+  module C = Dns_certify_mirage.Make(R)(Clock)(OS.Time)(S)
 
   let with_tls cfg tcp ~f =
     let peer, port = TCP.dst tcp in
@@ -50,15 +51,36 @@ module Make
     let t = D.create domain (D.redirect domain) in
     Http.listen t flow
 
-  let tls_init kv =
-    X509.certificate kv `Default >>= fun cert ->
-    let conf = Tls.Config.server ~certificates:(`Single cert) () in
-    Lwt.return conf
+  let restart_before_expire = function
+    | `Single (server :: _, _) ->
+      let expiry = snd (X509.Certificate.validity server) in
+      let diff = Ptime.diff expiry (Ptime.v (Clock.now_d_ps ())) in
+      begin match Ptime.Span.to_int_s diff with
+        | None -> invalid_arg "couldn't convert span to seconds"
+        | Some x when x < 0 -> invalid_arg "diff is negative"
+        | Some x ->
+          Lwt.async (fun () ->
+              OS.Time.sleep_ns
+                (Int64.sub (Duration.of_sec x) (Duration.of_day 1)) >|= fun () ->
+              exit 42)
+      end
+    | _ -> ()
 
-  let start stack keys fs tmpl () () =
+  let tls_init stack hostname =
+    C.retrieve_certificate stack ~dns_key:(Key_gen.dns_key ())
+      ~hostname ~key_seed:(Key_gen.key_seed ())
+      (Key_gen.dns_server ()) (Key_gen.dns_port ()) >>= function
+    | Error (`Msg m) -> Lwt.fail_with m
+    | Ok certificates ->
+      restart_before_expire certificates;
+      let conf = Tls.Config.server ~certificates () in
+      Lwt.return conf
+
+  let start _ stack fs tmpl () =
     let host = Key_gen.host () in
     let redirect = Key_gen.redirect () in
-    tls_init keys >>= fun cfg ->
+    let hostname = Domain_name.(of_string_exn (Key_gen.host ()) |> host_exn) in
+    tls_init stack hostname >>= fun cfg ->
     let domain = `Https, host in
     let dispatch = match redirect with
       | None        -> DS.dispatch domain fs tmpl

--- a/src/dispatch_tls.mli
+++ b/src/dispatch_tls.mli
@@ -17,15 +17,14 @@
 (** HTTPS dispatcher *)
 
 module Make
+    (R: Mirage_random.S)
     (S: Mirage_stack.V4)
-    (KEYS: Mirage_kv.RO)
     (FS: Mirage_kv.RO)
     (TMPL: Mirage_kv.RO)
     (Clock : Mirage_clock.PCLOCK) :
 sig
 
   val start:
-    S.t -> KEYS.t ->
-    FS.t -> TMPL.t -> unit -> unit -> unit Lwt.t
+    'a -> S.t -> FS.t -> TMPL.t -> unit -> unit Lwt.t
     (** The HTTP server's start function. *)
 end


### PR DESCRIPTION
hello,

this branch is used for mirageos.org where the TLS certificate is fetched from DNS. I am not entirely sure where this should be, my proposal would be:
- we continue master for mirage.io
- we create a new branch ("live" / "deploy") that uses the ocurrent pipeline to deploy as mirageos.org (atm the setup is another testing unikernel AFAIU, could we just use the real one (and mirageos.org) there @talex5)

once that is in, we'll occasionally need merges into both master and live branches (fine to rebase, and keep the last commit here as top of the branch to avoid divergence).

once that is settled, we discussed using load balancing and two unikernel images -- a hvt and a spt one -- I've no idea what this entails in terms of CI/ocurrent -- from the albatross perspective, we just need to put a solo5-spt into /var/lib/albatross (albatross uses solo5-elftool to invoke the right tender).