### PR TITLE
blog entry about tls 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ sudo: required
 dist: xenial
 env:
   matrix:
-  - OCAML_VERSION=4.07 MIRAGE_BACKEND=unix FLAGS="-vv --net socket"
-  - OCAML_VERSION=4.07 MIRAGE_BACKEND=unix FLAGS="-vv --net direct"
-  - OCAML_VERSION=4.07 MIRAGE_BACKEND=xen  XENIMG="openmirageorg"
+  - OCAML_VERSION=4.08 MIRAGE_BACKEND=unix FLAGS="-vv --net socket"
+  - OCAML_VERSION=4.08 MIRAGE_BACKEND=unix FLAGS="-vv --net direct"
+  - OCAML_VERSION=4.08 MIRAGE_BACKEND=xen  XENIMG="openmirageorg"
     PINS="travis-senv:https://github.com/hannesm/travis-senv.git#fix fat-filesystem:https://github.com/samoht/ocaml-fat.git#revert-sector-size"
     FLAGS="-vv --net direct --dhcp false --ipv4 46.43.42.135/28
     --ipv4-gateway 46.43.42.129
     --host openmirage.org --redirect https://mirage.io"
-  - OCAML_VERSION=4.07 MIRAGE_BACKEND=xen XENIMG="mirageio"
+  - OCAML_VERSION=4.08 MIRAGE_BACKEND=xen XENIMG="mirageio"
     PINS="travis-senv:https://github.com/hannesm/travis-senv.git#fix fat-filesystem:https://github.com/samoht/ocaml-fat.git#revert-sector-size"
     FLAGS="-vv --net direct --dhcp false --ipv4 46.43.42.136/28
     --ipv4-gateway 46.43.42.129 --tls true

--- a/src/data.ml
+++ b/src/data.ml
@@ -184,6 +184,12 @@ module Blog = struct
     let open Cowabloga.Date in
     let open Cowabloga.Blog.Entry in
     [
+      { updated    = date (2020, 05, 20, 14, 00);
+        authors    = [hannes];
+        subject    = "TLS 1.3 support for MirageOS";
+        body       = "tls-1-3-mirageos.md";
+        permalink  = "tls-1-3-mirageos";
+      };
       { updated    = date (2020, 01, 08, 20, 00);
         authors    = [damien_leloup];
         subject    = "Hackers and climate activists join forces in Leipzig";

--- a/tmpl/blog/tls-1-3-mirageos.md
+++ b/tmpl/blog/tls-1-3-mirageos.md
@@ -8,4 +8,4 @@ library (from [Project Everest](https://project-everest.github.io/)) for the X25
 
 Part of our TLS 1.3 stack is support for pre-shared keys, and 0 RTT. If you're keen to try these features, please do so and report any issues you encounter [to our issue tracker](https://github.com/mirleft/ocaml-tls).
 
-We are still lacking support for RSA-PSS certificates and EC certificates, post-handshake authentication, and the chacha20-poly1305 ciphersuite. We will continue to work on these, patches are welcome.
+We are still lacking support for RSA-PSS certificates and EC certificates, post-handshake authentication, and the chacha20-poly1305 ciphersuite. There is also a [minor symbol clash](https://github.com/mirage/hacl/issues/32) with the upstream F* C bindings which we are aware of. We will continue to work on these, and patches are welcome.

--- a/tmpl/blog/tls-1-3-mirageos.md
+++ b/tmpl/blog/tls-1-3-mirageos.md
@@ -1,6 +1,6 @@
 We are pleased to announce that [TLS 1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3) support for MirageOS is available. With
 mirage 3.7.7 and tls 0.12 the [Transport Layer Security (TLS) Protocol Version 1.3](https://tools.ietf.org/html/rfc8446)
-is available in all MirageOS unikernels, including on our main website.
+is available in all MirageOS unikernels, including on our main website. If you're reading this, you've likely established a TLS 1.3 connection already :)
 
 Getting there was some effort: we now embed the in Coq verified [fiat](https://github.com/mirage/fiat/)
 library (from [fiat-crypto](https://github.com/mit-plv/fiat-crypto/)) for the P-256 elliptic curve, and the with F* verified [hacl](https://github.com/mirage/hacl)

--- a/tmpl/blog/tls-1-3-mirageos.md
+++ b/tmpl/blog/tls-1-3-mirageos.md
@@ -2,8 +2,8 @@ We are pleased to announce that [TLS 1.3](https://en.wikipedia.org/wiki/Transpor
 mirage 3.7.7 and tls 0.12 the [Transport Layer Security (TLS) Protocol Version 1.3](https://tools.ietf.org/html/rfc8446)
 is available in all MirageOS unikernels, including on our main website. If you're reading this, you've likely established a TLS 1.3 connection already :)
 
-Getting there was some effort: we now embed the in Coq verified [fiat](https://github.com/mirage/fiat/)
-library (from [fiat-crypto](https://github.com/mit-plv/fiat-crypto/)) for the P-256 elliptic curve, and the with F* verified [hacl](https://github.com/mirage/hacl)
+Getting there was some effort: we now embed the Coq-verified [fiat](https://github.com/mirage/fiat/)
+library (from [fiat-crypto](https://github.com/mit-plv/fiat-crypto/)) for the P-256 elliptic curve, and the F*-verified [hacl](https://github.com/mirage/hacl)
 library (from [Project Everest](https://project-everest.github.io/)) for the X25519 elliptic curve to establish 1.3 handshakes with ECDHE.
 
 Part of our TLS 1.3 stack is support for pre-shared keys, and 0 RTT. If you're keen to try these features, please do so and report any issues you encounter [to our issue tracker](https://github.com/mirleft/ocaml-tls).

--- a/tmpl/blog/tls-1-3-mirageos.md
+++ b/tmpl/blog/tls-1-3-mirageos.md
@@ -1,0 +1,11 @@
+We are pleased to announce that [TLS 1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3) support for MirageOS is available. With
+mirage 3.7.7 and tls 0.12 the [Transport Layer Security (TLS) Protocol Version 1.3](https://tools.ietf.org/html/rfc8446)
+is available in all MirageOS unikernels, including on our main website.
+
+Getting there was some effort: we now embed the in Coq verified [fiat](https://github.com/mirage/fiat/)
+library (from [fiat-crypto](https://github.com/mit-plv/fiat-crypto/)) for the P-256 elliptic curve, and the with F* verified [hacl](https://github.com/mirage/hacl)
+library (from [Project Everest](https://project-everest.github.io/)) for the X25519 elliptic curve to establish 1.3 handshakes with ECDHE.
+
+Part of our TLS 1.3 stack is support for pre-shared keys, and 0 RTT. If you're keen to try these features, please do so and report any issues you encounter [to our issue tracker](https://github.com/mirleft/ocaml-tls).
+
+We are still lacking support for RSA-PSS certificates and EC certificates, post-handshake authentication, and the chacha20-poly1305 ciphersuite. We will continue to work on these, patches are welcome.


### PR DESCRIPTION
review & feedback welcome. this should entail CI using mirage 3.7.7 and tls 0.12.0 to get mirage.io/mirageos.org running with tls 1.3 :)