### PR TITLE
Treat letsencrypt-related options as required only when TLS is enabled

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -26,7 +26,7 @@ open Mirage
 
 let tls_key =
   let doc = Key.Arg.info
-      ~doc:"Enable serving the website over https. Do not forget to put certificates in tls/"
+      ~doc:"Enable serving the website over https. Requires --dns-key, --dns-server and --key-seed."
       ~docv:"BOOL" ~env:"TLS" ["tls"]
   in
   Key.(create "tls" Arg.(opt ~stage:`Configure bool false doc))
@@ -69,19 +69,19 @@ let redirect_key =
 
 let dns_key =
   let doc = Key.Arg.info ~doc:"nsupdate key (name:type:value,...)" ["dns-key"] in
-  Key.(create "dns-key" Arg.(required string doc))
+  Key.(create "dns-key" Arg.(opt (some string) None doc))
 
 let dns_server =
   let doc = Key.Arg.info ~doc:"dns server IP" ["dns-server"] in
-  Key.(create "dns-server" Arg.(required ipv4_address doc))
+  Key.(create "dns-server" Arg.(opt (some ipv4_address) None doc))
 
 let dns_port =
   let doc = Key.Arg.info ~doc:"dns server port" ["dns-port"] in
-  Key.(create "dns-port" Arg.(opt int 53 doc))
+  Key.(create "dns-port" Arg.(opt (some int) (Some 53) doc))
 
 let key_seed =
   let doc = Key.Arg.info ~doc:"certificate key seed" ["key-seed"] in
-  Key.(create "key-seed" Arg.(required string doc))
+  Key.(create "key-seed" Arg.(opt (some string) None doc))
 
 let additional_hostnames =
   let doc = Key.Arg.info ~doc:"Additional names (used for certificates)" ["additional-hostname"] in

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -67,7 +67,7 @@ module Make
     | _ -> ()
 
   let required key_name key =
-    match (key ()) with
+    match key () with
       | Some x -> x
       | None -> Log.err (fun m -> m "TLS is enabled but required key %s missing" key_name); exit 64
 

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -66,10 +66,15 @@ module Make
       end
     | _ -> ()
 
+  let required key_name key =
+    match (key ()) with
+      | Some x -> x
+      | None -> Log.err (fun m -> m "TLS is enabled but required key %s missing" key_name); exit 64
+
   let tls_init stack hostname additional_hostnames =
-    C.retrieve_certificate stack ~dns_key:(Key_gen.dns_key ())
-      ~hostname ~additional_hostnames ~key_seed:(Key_gen.key_seed ())
-      (Key_gen.dns_server ()) (Key_gen.dns_port ()) >>= function
+    C.retrieve_certificate stack ~dns_key:(required "--dns-key" Key_gen.dns_key)
+      ~hostname ~additional_hostnames ~key_seed:(required "--key-seed" Key_gen.key_seed)
+      (required "--dns-server" Key_gen.dns_server) (required "--dns-port" Key_gen.dns_port) >>= function
     | Error (`Msg m) -> Lwt.fail_with m
     | Ok certificates ->
       restart_before_expire certificates;


### PR DESCRIPTION
Treat `--dns-key`, `--dns-server`, `--dns-port` and `--key-seed` as required only when TLS has been enabled at configure time (with `--tls=true`).

This allows for easily running the website unikernel locally for preview purposes.

I'm not 100% sure that the current failure mode is the best way to go about it; if `--tls` is configured but the options are not given, then you get this:

```
2020-10-26 12:06:57 -00:00: INF [netif] Plugging into service with mac 16:bf:19:7c:1b:40 mtu 1500
2020-10-26 12:06:57 -00:00: INF [ethernet] Connected Ethernet interface 16:bf:19:7c:1b:40
2020-10-26 12:06:57 -00:00: INF [ARP] Sending gratuitous ARP for 10.0.0.2 (16:bf:19:7c:1b:40)
2020-10-26 12:06:57 -00:00: INF [udp] UDP interface connected on 10.0.0.2
2020-10-26 12:06:57 -00:00: INF [tcpip-stack-direct] stack assembled: mac=16:bf:19:7c:1b:40,ip=10.0.0.2
Fatal error: exception (Invalid_argument "--tls is enabled but required key missing, see --help")
Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
Called from Dispatch_tls.Make.required in file "dispatch_tls.ml" (inlined), line 72, characters 16-83
Called from Dispatch_tls.Make.tls_init in file "dispatch_tls.ml", line 77, characters 6-41
Called from Dispatch_tls.Make.start in file "dispatch_tls.ml", line 92, characters 4-48
Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
Called from Main in file "main.ml", line 220, characters 2-240
Solo5: solo5_exit(2) called
``` 

What's a less verbose and more obvious way to exit in this case?

Also, can I get the actual missing key name into the exception error message somehow? If so, how?