### PR TITLE
Mirage 4 docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,12 @@ stats/.merlin
 .*.swp
 
 /src/.mirage.config
-/src/mirage-unikernel-www-*.opam
-/src/myocamlbuild.ml
-/src/www
-/src/www.hvt
-/src/www.spt
+/src/dist/
+/src/mirage/
+/src/duniverse/
+/src/dune-workspace
 
 _opam
 .envrc
+
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ocaml/opam:ubuntu-ocaml-4.11
 RUN sudo apt install -y m4 pkg-config
-RUN cd ~/opam-repository && git pull origin master && git reset --hard ee6c1009d891d8b1ee4d68cee90cd66c2ab4fb3b && opam update
-RUN opam repo add mirage-dev https://github.com/mirage/mirage-dev.git#dcc79014e10006b1b84fe5ed45c5ef067dc4caf7
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 7af4b295dc2de0b2b594c05ab4af40ef963bbc5c && opam update
+RUN opam repo add mirage-dev https://github.com/mirage/mirage-dev.git#713b884b36a58579515b2ea55ec057f6fe310a52
 RUN opam depext -ui mirage
 RUN mkdir -p /home/opam/www/src
 WORKDIR /home/opam/www/src
 COPY --chown=opam:root src/config.ml /home/opam/www/src/
 ARG TARGET=unix
 ARG EXTRA_FLAGS=
-RUN opam config exec -- mirage configure -t $TARGET $EXTRA_FLAGS
+RUN opam config exec -- mirage configure -t $TARGET $EXTRA_FLAGS --extra-repo https://github.com/mirage/opam-overlays.git#aa30403f107034500e5f697ddfc6e954117fc059
 RUN opam config exec -- make depend
 COPY --chown=opam:root . /home/opam/www
-RUN opam config exec -- mirage configure -t $TARGET $EXTRA_FLAGS
+RUN opam config exec -- mirage configure -t $TARGET $EXTRA_FLAGS --extra-repo https://github.com/mirage/opam-overlays.git#aa30403f107034500e5f697ddfc6e954117fc059
 RUN opam config exec -- mirage build
 RUN if [ $TARGET = hvt ]; then sudo cp dist/www.$TARGET /unikernel.$TARGET; fi

--- a/src/data.ml
+++ b/src/data.ml
@@ -173,6 +173,12 @@ module People = struct
     uri       = Some "https://www.lemonde.fr/signataires/damien-leloup/";
     email     = None;
   }
+
+  let lortex = {
+    Atom.name = "Lucas Pluvinage";
+    uri       = Some "https://lortex.org/";
+    email     = Some "lucas@tarides.com";
+  }
 end
 
 let rights = Some "All rights reserved by the author"
@@ -903,6 +909,13 @@ module Wiki = struct
       subject    = "Building and packaging with dune and dune-release";
       body       = File "packages.md";
       permalink  = "packaging";
+    };
+
+    { updated    = date (2021, 04, 14, 17, 46);
+      author     = lortex;
+      subject    = "MirageOS 4";
+      body       = File "mirage-4.md";
+      permalink  = "mirage-4";
     };
   ]
 end

--- a/src/files/css/site.css
+++ b/src/files/css/site.css
@@ -28,6 +28,7 @@ article a:hover {
 
 body {
   background-image: url(/graphics/cloud-bg.png);
+  background-position-y: 32px;
   background-repeat: repeat-x;
   padding-bottom: 1.5em;
 }
@@ -37,9 +38,6 @@ code {
   margin-bottom: 1em;
   font-size: 100%;
   line-height: 1.2;
-  word-break: break-all;
-  word-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .side-nav li a {

--- a/src/pages.ml
+++ b/src/pages.ml
@@ -75,6 +75,17 @@ module Global = struct
       ~title_uri:(Uri.of_string "/")
       ~nav_links
 
+  let mirage_4_announce =
+      div ~id:"mirage-4-announce" ~attrs:["style", "background-color: #627288; padding: 8px 0; color: white;"] (
+        div ~cls:"row" (
+        div ~cls:"small-12 columns" (
+          string "MirageOS 4.0 is on its way ! See the "
+          ++ a ~attrs:["style", "color: wheat"] ~href:(Uri.of_string "/docs/mirage-4") (string "documentation")
+          ++ string " for more information on what's new, and how to test the preview."
+        )
+      )
+    )
+
   let t ~title ~headers ~content ~read:_ ~domain =
     let scheme = match fst domain with `Http -> "http" | `Https -> "https" in
     let fonts =
@@ -86,7 +97,7 @@ module Global = struct
       link ~rel:"stylesheet" ~ty:"text/css" (Uri.of_string fonts)
     in
     let headers = font @ headers in
-    let content = top_nav @ content in
+    let content = top_nav @ mirage_4_announce @ content in
     let google_analytics = Data.google_analytics domain in
     let body =
       Cowabloga.Foundation.body ~highlight:"/css/magula.css"

--- a/src/tmpl/wiki/mirage-4.md
+++ b/src/tmpl/wiki/mirage-4.md
@@ -1,0 +1,140 @@
+Welcome to the MirageOS 4 release page. No official announcement has been made, 
+but the current work is available as a bleeding-edge repository.
+
+You can follow the advances in the release process through the 
+[tracking issue](https://github.com/mirage/mirage/issues/1217).
+
+### What's new ?
+
+The main change is a deep modification on how unikernels are built. One of the 
+purposes of MirageOS is to orchestrate a build a system in order to produce the desired
+unikernel binary. Until MirageOS 4, the build system was `ocamlbuild`. Now, we switched 
+to `dune`. Following a global shift to the `dune` build system, this enables us many 
+features that were slowing down the MirageOS development workflow.
+
+- **Monorepos**: unikernel sources are locally fetched to be compiled by `dune`. This 
+  implies that one can locally edit theses sources to test changes, before sending them
+  to the upstream repository. It replaces the usual `opam pin ...` / edit sources /
+  `opam reinstall ...` workflow.
+
+  The monorepos are built using the [opam-monorepo](https://github.com/ocamllabs/opam-monorepo) 
+  tool, consisting in two steps. First a lockfile is generated, performing the 
+  dependency resolution and locking packages to specific versions. Then the lockfile is 
+  used to locally fetch the sources.
+
+- **Cross-compilation**: one of the problems of MirageOS 3.x was the difficulty to create
+  new targets into the ecosystem, especially cross-archicture targets. Because opam 
+  installs packages for the host architecture, one would have to create a parallel 
+  repository in which packages are cross-compiled, such as 
+  [opam-cross-android](https://github.com/ocaml-cross/opam-cross-android) or 
+  [opam-cross-esp32](https://github.com/well-typed-lightbulbs/opam-cross-esp32). That 
+  _parallel world_ idea has also been implemented using `esy`: see 
+  [reason-mobile](https://github.com/EduardoRFS/reason-mobile).
+
+  The MirageOS 4 solution takes advantage of the dune _workspaces_ feature, which 
+  defines a global compilation environment (OCaml compiler, C compiler, flags and 
+  environment variables) to be used to build all the sources that are locally available.
+  As a consequence, porting a new target to Mirage 4 will only rely on having a 
+  _freestanding_ (i.e. OS-free) OCaml compiler. 
+
+- **Reproducible workflow**: because lockfiles are used to fetch the unikernel sources,
+  we can ensure that the exact same sources will be used to build the unikernel as the as
+  the lockfile has not changed. Additional work might be required to ensure that the 
+  rest of the tools (mirage, dune, ocaml-freestanding) are also locked to a specific 
+  version.
+
+- **Merlin support**: `dune` automatically enables the usage of `merlin` to improve the
+  developper experience. Its editor support can be enabled for example by using the ocaml
+  LSP server. Due to current limitations, `merlin` can be enabled either on the 
+  `config.ml` file or the unikernel files, but not both at the same time.
+
+  Note that until the next release of `dune`, `merlin` support must be activated manually 
+  in the `dune-workspace` file. [documentation](https://dune.readthedocs.io/en/stable/dune-files.html#context)
+
+### Ecosystem changes
+
+- **Port to dune**: since the beginning of the work on MirageOS 4, many packages have
+  been ported to dune. This is a _requirement_ to be able to use it in a unikernel. 
+  The libraries using alternative build systems (such as `B0`) have been ported to `dune`,
+  but as upstreaming the work is not expected, the MirageOS team maintains a repository
+  of _build system forks_: [mirage/opam-overlays](https://github.com/mirage/opam-overlays). 
+
+  The mission of porting and maintaining _dune-built_ forks is assured by the 
+  [dune-universe](https://github.com/dune-universe) team.
+
+- **Solo5 and OCaml-freestanding**: to support the new _cross-compilation_ workflow, 
+  `solo5` becomes a cross-compilation toolchain (`ARCH-solo5-none-static-cc`) and 
+  `ocaml-freestanding` becomes an OCaml cross-compiler based on that solo5 toolchain. 
+
+- **C stubs compilation**: the rule for C stubs compilation has also changed. Until now,
+  package maintainers that uses C stubs had to add some code to build the C stubs using the
+  `solo5` flags, through the `ocaml-freestanding` `pkg-config` file.
+
+  Now, package maintainers should only care about writing portable code once, and built it 
+  using `dune` rules.
+
+
+To sum it up, here are the **portable compilation rules** for a package to support Mirage 4.0: 
+1) Don't depend on `unix`
+2) Build your project with `dune`, and have your transitive dependencies buildable using `dune`.
+3) If your project use C stubs, assume the `libc` is minimal.
+
+### Tool changes
+
+##### API breakages
+
+The functoria devices has changed, switching from requesting objects to a function with optional parameters.
+An additional `dune` field can be used to have additional rules related to the device. 
+
+See this [commit](https://github.com/mirage/mirage-skeleton/commit/4d3f7afdcfdff9136cd4e3973afdce9de4934178) as 
+an example on how to adapt the objects to the new interface.
+
+##### Configure
+
+The `mirage` command-line interface hasn't fundamentally changed, but when a project is _configured_, 
+the following additional files are generated:
+
+- **dune.build**: the dune rules to build the unikernel.
+- **dune-workspace**: the compilation workspace definition, asking dune to use the ocaml-freestanding 
+  cross-compiler. 
+- **mirage/UNIKERNEL.opam**: the unikernel dependencies to lock and fetch.
+- **mirage/UNIKERNEL-install.opam**: the tool dependencies to `opam-install` (it includes `solo5` and `ocaml-freestanding`)
+
+##### Fetch
+
+To fetch and install the dependencies, `make depends` is still the command to go:
+- it globally, installs using `opam`, the build dependencies
+- it fetches, using `opam-monorepo` the unikernel dependencies.
+
+##### Build
+
+To build the unikernel, `mirage build` and `dune build` are equivalent.
+The output is available in the `dist/` folder. 
+
+### How to test 
+
+```sh
+# Add the MirageOS 4 development repository
+$ opam repo add mirage https://github.com/mirage/mirage-dev.git#mirage-4
+
+# Install MirageOS 4
+$ opam install mirage
+
+# Clone this website
+$ git clone https://github.com/mirage/mirage-www -b next
+
+# Go in the source folder
+$ cd mirage-www/src
+
+# Configure the unikernel
+$ mirage configure -t hvt
+
+# Fetch and install dependencies
+$ make depend
+
+# Build the unikernel
+$ mirage build
+
+# Launch it (a tap interface needs to be configured for the hvt target)
+$ solo5-hvt --net:service=tap100 dist/www.hvt
+```


### PR DESCRIPTION
This PR adds a new `/docs/mirage-4` page that roughly explains the changes and how to test it. I intend to use `next.mirage.io/docs/mirage-4` as the entry point to explain the changes and to let people test the bleeding-edge work. 

It also adds a banner under the top navigator bar to announce the upcoming release 