### PR TITLE
pass a stack v4v6 to conduit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocurrent/opam:ubuntu-20.10-ocaml-4.10
 RUN sudo apt install -y m4 pkg-config
 RUN cd ~/opam-repository && git pull origin master && git reset --hard ef82e5bc09e89868e9393bc8ded218b02517876e && opam update
-RUN opam repo add mirage-dev https://github.com/mirage/mirage-dev.git#713b884b36a58579515b2ea55ec057f6fe310a52
+RUN opam repo add mirage-dev https://github.com/mirage/mirage-dev.git#0c7c0a14240236bf00c5ccdceab0612f09cbe339
 RUN opam depext -ui mirage
 RUN mkdir -p /home/opam/www/src
 WORKDIR /home/opam/www/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:ubuntu-ocaml-4.11
 RUN sudo apt install -y m4 pkg-config
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 7af4b295dc2de0b2b594c05ab4af40ef963bbc5c && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard ef82e5bc09e89868e9393bc8ded218b02517876e && opam update
 RUN opam repo add mirage-dev https://github.com/mirage/mirage-dev.git#713b884b36a58579515b2ea55ec057f6fe310a52
 RUN opam depext -ui mirage
 RUN mkdir -p /home/opam/www/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:ubuntu-ocaml-4.11
+FROM ocurrent/opam:ubuntu-20.10-ocaml-4.10
 RUN sudo apt install -y m4 pkg-config
 RUN cd ~/opam-repository && git pull origin master && git reset --hard ef82e5bc09e89868e9393bc8ded218b02517876e && opam update
 RUN opam repo add mirage-dev https://github.com/mirage/mirage-dev.git#713b884b36a58579515b2ea55ec057f6fe310a52

--- a/src/config.ml
+++ b/src/config.ml
@@ -101,7 +101,7 @@ let dispatch = if_impl (Key.value tls_key)
     (https $ default_random $ generic_stackv4 default_network)
 
     (* Without tls *)
-    (http $ cohttp_server (conduit_direct (generic_stackv4 default_network)))
+    (http $ cohttp_server (conduit_direct (generic_stackv4v6 default_network)))
 
 let packages = [
   package "cow" ~min:"2.3.0";

--- a/src/config.ml
+++ b/src/config.ml
@@ -94,11 +94,11 @@ let https =
   let packages = [package "tls-mirage"; package "cohttp-mirage"] in
   let keys = keys @ tls_only_keys in
   foreign ~packages  ~keys "Dispatch_tls.Make"
-    (random @-> stackv4 @-> kv_ro @-> kv_ro @-> pclock @-> job)
+    (random @-> stackv4v6 @-> kv_ro @-> kv_ro @-> pclock @-> job)
 
 let dispatch = if_impl (Key.value tls_key)
     (* With tls *)
-    (https $ default_random $ generic_stackv4 default_network)
+    (https $ default_random $ generic_stackv4v6 default_network)
 
     (* Without tls *)
     (http $ cohttp_server (conduit_direct (generic_stackv4v6 default_network)))

--- a/src/config.ml
+++ b/src/config.ml
@@ -58,7 +58,7 @@ let dns_key =
 
 let dns_server =
   let doc = Key.Arg.info ~doc:"dns server IP" ["dns-server"] in
-  Key.(create "dns-server" Arg.(required ipv4_address doc))
+  Key.(create "dns-server" Arg.(required ip_address doc))
 
 let dns_port =
   let doc = Key.Arg.info ~doc:"dns server port" ["dns-port"] in

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -18,7 +18,7 @@ open Lwt.Infix
 
 module Make
     (R: Mirage_random.S)
-    (S: Mirage_stack.V4)
+    (S: Mirage_stack.V4V6)
     (FS: Mirage_kv.RO)
     (TMPL: Mirage_kv.RO)
     (Clock : Mirage_clock.PCLOCK)

--- a/src/dispatch_tls.ml
+++ b/src/dispatch_tls.ml
@@ -39,7 +39,7 @@ module Make
   module C = Dns_certify_mirage.Make(R)(Clock)(OS.Time)(S)
 
   let restart_before_expire = function
-    | `Single (server :: _, _) ->
+    | (server :: _, _) ->
       let expiry = snd (X509.Certificate.validity server) in
       let diff = Ptime.diff expiry (Ptime.v (Clock.now_d_ps ())) in
       begin match Ptime.Span.to_int_s diff with
@@ -60,7 +60,7 @@ module Make
     | Error (`Msg m) -> Lwt.fail_with m
     | Ok certificates ->
       restart_before_expire certificates;
-      let conf = Tls.Config.server ~certificates () in
+      let conf = Tls.Config.server ~certificates:(`Single certificates) () in
       Lwt.return conf
 
   let start _ stack fs tmpl () =

--- a/src/dispatch_tls.mli
+++ b/src/dispatch_tls.mli
@@ -18,7 +18,7 @@
 
 module Make
     (R: Mirage_random.S)
-    (S: Mirage_stack.V4)
+    (S: Mirage_stack.V4V6)
     (FS: Mirage_kv.RO)
     (TMPL: Mirage_kv.RO)
     (Clock : Mirage_clock.PCLOCK) :


### PR DESCRIPTION
`conduit_direct` expects a dual-stack argument these days.