### PR TITLE
Implement caching for static files

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,3 @@
 version = 0.20.1
 profile = default
+ocaml-version = 4.10.0

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   dune
   dream
   dream-mirage
+  mirage-kv-mem
   mirage-clock-unix
   mirage-unix
   (crunch :build)

--- a/lib/dune
+++ b/lib/dune
@@ -1,9 +1,9 @@
 (library
  (name mirageio)
- (libraries dream-mirage mirage-time tcpip mirageio_template mirageio_data))
+ (libraries dream-mirage mirage-time tcpip mirageio_template mirageio_data mirage-kv-mem))
 
 (rule
- (targets asset.ml)
+ (targets asset.ml asset.mli)
  (deps
   ; Not specifying dependencies on main.css on purpose so we can skip the generation
   ; of the CSS file if we only want to run the server.
@@ -13,4 +13,4 @@
  (action
   (with-stdout-to
    %{null}
-   (run %{bin:ocaml-crunch} -m plain ../asset -o %{targets}))))
+   (run %{bin:ocaml-crunch} -m lwt ../asset -o asset.ml))))

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "2.7"}
   "dream"
   "dream-mirage"
+  "mirage-kv-mem"
   "mirage-clock-unix"
   "mirage-unix"
   "crunch" {build}

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -39,8 +39,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/tmattio/mirageio.git"
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"]
+  ["dream.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"] # branch master+mirage
+  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"]
+  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"]
+  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"]
 ]

--- a/mirageio.opam.template
+++ b/mirageio.opam.template
@@ -1,6 +1,6 @@
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#ba08fc242e2c9acec9978f07ac2bdba7bd3e4e55"]
+  ["dream.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"] # branch master+mirage
+  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"]
+  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"]
+  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#c3b2592481693507df42e6df821dd7f509793f52"]
 ]


### PR DESCRIPTION
Caching is hard, so as a first implementation I've added the following, only for files that are served statically:
- new response header `Cache-Control: max-age=3600`: static files are cached for one hour, once the website gets stabilized we could bump that up to 1 day or more
- new response header `Etag: "xxx"` is a tag that is used so that the client can ask, when the resource has expired, whether the content has actually changed. Currently, the tag is the hash of all the static files. At some point we could make it so that crunch computes the hashes for each file. For now it's a good enough approximation.
- parse request header `If-None-Match: "xxx"` that should return 304 not modified if the Etag matches what the client has in cache.