### PR TITLE
Mirage 4 / announcement pages updates

### DIFF
--- a/data/blog/announcing-mirage-40-beta-release.md
+++ b/data/blog/announcing-mirage-40-beta-release.md
@@ -42,7 +42,9 @@ That new tool, called [opam-monorepo](https://github.com/ocamllabs/opam-monorepo
 
 [![asciicast](https://asciinema.org/a/rRf6s8cNyHUbBsDDfZkBjkf7X.svg)](https://asciinema.org/a/rRf6s8cNyHUbBsDDfZkBjkf7X?speed=2)
 
-`opam-monorepo` is already available in Opam and can be used on many projects which use `dune` as a build system. However, as we don't expect the complete set of OCaml dependencies to use `dune`, we MirageOS maintainers are committed to maintaining patches to build the most common dependencies with `dune`. These packages are hosted in a separate [dune-universe/mirage-opam-overlays](https://github.com/mirage/opam-overlays) repository, which can be used by `opam-monorepo` and is enabled by default when using the Mirage CLI tool.
+`opam-monorepo` is already available in Opam and can be used on many projects which use `dune` as a build system. However, as we don't expect the complete set of OCaml dependencies to use `dune`, we MirageOS maintainers are committed to maintaining patches to build the most common dependencies with `dune`. Two repositories are used for that purpose:
+- [dune-universe/opam-overlays](https://github.com/dune-universe/opam-overlays) is set up by default by `opam-monorepo` and contains most packages.
+- [dune-universe/mirage-opam-overlays](https://github.com/dune-universe/mirage-opam-overlays) is enabled when using the Mirage CLI tool. 
 
 ## Next Steps
 

--- a/data/wiki/mirage-4.md
+++ b/data/wiki/mirage-4.md
@@ -1,5 +1,5 @@
 ---
-updated: 2022-01-24 16:00
+updated: 2022-02-11 16:00
 author:
   name: Thomas Gazagnaire
   uri: http://gazagnaire.org
@@ -8,11 +8,7 @@ subject: Mirage 4
 permalink: mirage-4
 ---
 
-Welcome to the MirageOS 4 release page. No official announcement has been made, 
-but the current work is available as a bleeding-edge repository.
-
-You can follow the advances in the release process through the 
-[tracking issue](https://github.com/mirage/mirage/issues/1217).
+Welcome to the MirageOS 4 release page. 
 
 ### What's new ?
 
@@ -66,8 +62,8 @@ features that were slowing down the MirageOS development workflow.
 - **Port to dune**: since the beginning of the work on MirageOS 4, many packages have
   been ported to dune. This is a _requirement_ to be able to use it in a unikernel. 
   The libraries using alternative build systems (such as `B0`) have been ported to `dune`,
-  but as upstreaming the work is not expected, the MirageOS team maintains a repository
-  of _build system forks_: [mirage/opam-overlays](https://github.com/mirage/opam-overlays). 
+  but as upstreaming the work is not expected, the MirageOS team maintains repositories
+  of _build system forks_: [dune-universe/opam-overlays](https://github.com/dune-universe/opam-overlays) and [dune-universe/mirage-opam-overlays](https://github.com/dune-universe/mirage-opam-overlays). 
 
   The mission of porting and maintaining _dune-built_ forks is assured by the 
   [dune-universe](https://github.com/dune-universe) team.
@@ -127,27 +123,21 @@ The output is available in the `dist/` folder.
 ### How to test 
 
 ```sh
-# Add the MirageOS 4 development repository
-$ opam repo add mirage https://github.com/mirage/mirage-dev.git#master
-
 # Install MirageOS 4
-$ opam install mirage
+$ opam install 'mirage>=4.0'
 
-# Clone this website
-$ git clone https://github.com/mirage/mirage-www -b next
-
-# Go in the source folder
-$ cd mirage-www/src
+# Clone this website repository
+$ git clone https://github.com/mirage/mirage-www
 
 # Configure the unikernel
-$ mirage configure -t hvt
+$ mirage configure -f mirage/config.ml -t hvt
 
 # Fetch and install dependencies
 $ make depend
 
 # Build the unikernel
-$ mirage build
+$ dune build mirage/
 
 # Launch it (a tap interface needs to be configured for the hvt target)
-$ solo5-hvt --net:service=tap100 dist/www.hvt
+$ solo5-hvt --net:service=tap100 mirage/dist/www.hvt
 ```


### PR DESCRIPTION
Now that the tool is released in opam it makes sense to update the https://next.mirage.io/docs/mirage-4 page.

Also in the announcement it might make sense to point both to dune-universe/opam-overlays and dune-universe/mirage-opam-overlays.

 