### PR TITLE
Fix pin-depend on 'yaml'

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -106,7 +106,7 @@ let packages =
     package ~build:true
       ~pin:
         "git+https://github.com/TheLortex/ocaml-yaml.git#7e1f117645ea10fbec2bd3dbbf0d8f581cce891f"
-      "yaml";
+      ~pin_version:"3.0.0~dev" "yaml";
   ]
 
 let https =


### PR DESCRIPTION
The constraints have changed in opam and we need to specify the pinned version of `yaml`. This requires a patch to mirage: https://github.com/mirage/mirage/pull/1295

Perhaps we need a workaround that doesn't use a patched version of mirage ?