### PR TITLE
Update to latest dream

### DIFF
--- a/lib/mirageio.ml
+++ b/lib/mirageio.ml
@@ -165,7 +165,7 @@ struct
     let router = Dream.router routes
   end
 
-  let router = Dream.logger @@ Router.router @@ Dream.not_found
+  let router = Dream.logger @@ Router.router
   let http ?(port = 80) stack = Dream.http ~port (Stack.tcp stack) router
 
   let https ?(port = 443) ?tls stack =


### PR DESCRIPTION
Fixes:

```
File "lib/mirageio.ml", line 168, characters 48-63:
168 |   let router = Dream.logger @@ Router.router @@ Dream.not_found
                                                      ^^^^^^^^^^^^^^^
Error: This expression has type
         Dream.handler = Dream.request -> Dream.response Dream.promise
       but an expression was expected of type
         Dream.request = Dream.client Dream.message
```