### PR TITLE
Fix dream

### DIFF
--- a/lib/mirageio.ml
+++ b/lib/mirageio.ml
@@ -165,7 +165,7 @@ struct
     let router = Dream.router routes
   end
 
-  let router = Dream.logger @@ Router.router @@ Dream.not_found
+  let router = Dream.logger @@ Router.router
   let http ?(port = 80) stack = Dream.http ~port (Stack.tcp stack) router
 
   let https ?(port = 443) ?tls stack =

--- a/lib/mirageio.ml
+++ b/lib/mirageio.ml
@@ -165,7 +165,7 @@ struct
     let router = Dream.router routes
   end
 
-  let router = Dream.logger @@ Router.router
+  let router = Dream.logger @@ Router.router @@ Dream.not_found
   let http ?(port = 80) stack = Dream.http ~port (Stack.tcp stack) router
 
   let https ?(port = 443) ?tls stack =

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -40,9 +40,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/tmattio/mirageio.git"
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"]
+  ["dream.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"] # branch master+mirage
+  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
+  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
+  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6"]
 ]

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -40,9 +40,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/tmattio/mirageio.git"
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
+  ["dream.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"] # branch master+mirage
+  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"]
+  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"]
+  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6"]
 ]

--- a/mirageio.opam.template
+++ b/mirageio.opam.template
@@ -1,7 +1,7 @@
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#2c51f27a36a10efbc939ed2fe26ee515e507093e"]
+  ["dream.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"] # branch master+mirage
+  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
+  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
+  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6"]
 ]

--- a/mirageio.opam.template
+++ b/mirageio.opam.template
@@ -1,7 +1,7 @@
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#78991aad7d2372b391178b148ce69fd4707de116"]
+  ["dream.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"] # branch master+mirage
+  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"]
+  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"]
+  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#650b216d0f8b6f322110b80f03eaa5183b88a8d4"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6"]
 ]


### PR DESCRIPTION
Currently the site is broken, not serving page correctly as the connection hangs. 

@hannesm pointed the correct issue which was that I missed the content-length management code that had moved when rebasing the dream+mirage fork https://github.com/TheLortex/dream/pull/2.

So first commit is using the version of dream that has worked in the past. Second commit is an updated dream with hannes' patch.