### PR TITLE
Update github URLs to use https://

### DIFF
--- a/data/blog/introducing-irmin-in-xenstore.md
+++ b/data/blog/introducing-irmin-in-xenstore.md
@@ -311,7 +311,7 @@ Install the OCaml build dependencies:
 ```
 Clone the code and build it:
 ```
-  git clone git://github.com/mirage/ocaml-xenstore-server
+  git clone https://github.com/mirage/ocaml-xenstore-server
   cd ocaml-xenstore-server
   make
 ```

--- a/data/blog/introducing-vchan.md
+++ b/data/blog/introducing-vchan.md
@@ -62,7 +62,7 @@ This will install the library and its dependencies. `mirari` is
 necessary to build the *echo unikernel*:
 
 ```
-    git clone git://github.com/mirage/ocaml-vchan
+    git clone https://github.com/mirage/ocaml-vchan
     cd test
     mirari configure --xen --no-install
     mirari build --xen

--- a/data/blog/introducing-xen-minios-arm.md
+++ b/data/blog/introducing-xen-minios-arm.md
@@ -96,7 +96,7 @@ the xen-arm-builder image:
 ```bash
 $ opam init
 $ opam install mirage-xen-minios
-$ opam remote add mirage-dev git://github.com/mirage/mirage-dev
+$ opam remote add mirage-dev https://github.com/mirage/mirage-dev
 $ opam install mirage
 ```
 

--- a/data/blog/xen-block-devices-with-mirage.md
+++ b/data/blog/xen-block-devices-with-mirage.md
@@ -103,8 +103,8 @@ should not be necessary after the Mirage developer preview at
 [OSCON 2013](http://www.oscon.com/oscon2013/public/schedule/detail/28956).
 
 ```
-  opam remote add mirage-dev git://github.com/mirage/opam-repo-dev
-  opam remote add xapi-dev git://github.com/xapi-project/opam-repo-dev
+  opam remote add mirage-dev https://github.com/mirage/opam-repo-dev
+  opam remote add xapi-dev https://github.com/xapi-project/opam-repo-dev
 ```
 
 Install the unmodified `xen-disk` package, this will ensure all the build
@@ -130,7 +130,7 @@ used for basic testing!
 Assuming that worked ok, clone and build the source for `xen-disk` yourself:
 
 ```
-  git clone git://github.com/mirage/xen-disk
+  git clone https://github.com/mirage/xen-disk
   cd xen-disk
   make
 ```

--- a/data/blog/xenstore-stub.md
+++ b/data/blog/xenstore-stub.md
@@ -112,7 +112,7 @@ First install OCaml and the usual build tools:
 ```
 Then install the OCamlPro `opam` package manager to simplify the installation of extra packages
 ```
-    git clone git://github.com/OCamlPro/opam.git
+    git clone https://github.com/OCamlPro/opam.git
     cd opam
     make
     make install
@@ -125,7 +125,7 @@ Initialise OPAM with the default packages:
 ```
 Add the "mirage" development package source (this step will not be needed once the package definitions are upstreamed)
 ```
-    opam remote -add dev git://github.com/mirage/opam-repo-dev
+    opam remote -add dev https://github.com/mirage/opam-repo-dev
 ```
 Switch to the special "mirage" version of the OCaml compiler
 ```
@@ -144,7 +144,7 @@ Install the Mirage development libraries
 If this fails with "+ runtime/dietlibc/lib/atof.c:1: sorry, unimplemented: 64-bit mode not compiled in" it means you need a 64-bit build environment.
 Next, clone the xen stubdom tree
 ```
-    git clone git://github.com/djs55/ocaml-xenstore-xen
+    git clone https://github.com/djs55/ocaml-xenstore-xen
 ```
 Build the Xen stubdom
 ```

--- a/data/wiki/hello-world.md
+++ b/data/wiki/hello-world.md
@@ -15,7 +15,7 @@ the [mirage-skeleton](http://github.com/mirage/mirage-skeleton) repository.
 Begin by cloning and changing directory to it:
 
 ```bash
-$ git clone git://github.com/mirage/mirage-skeleton.git
+$ git clone https://github.com/mirage/mirage-skeleton.git
 $ cd mirage-skeleton
 ```
 

--- a/data/wiki/mirage-www.md
+++ b/data/wiki/mirage-www.md
@@ -19,7 +19,7 @@ actually serve the traffic.
 First, clone the website [source code](https://github.com/mirage/mirage-www):
 
 ```
-$ git clone git://github.com/mirage/mirage-www
+$ git clone https://github.com/mirage/mirage-www
 $ cd mirage-www/src
 $ cat config.ml
 ```

--- a/data/wiki/xen-on-cubieboard2.md
+++ b/data/wiki/xen-on-cubieboard2.md
@@ -115,7 +115,7 @@ Take note of the common prefix.  Define a variable to hold it:
 
 Xen needs to be started in non-secure HYP mode. Use this U-Boot Git repository:
 
-    git clone git://github.com/jwrdegoede/u-boot-sunxi.git
+    git clone https://github.com/jwrdegoede/u-boot-sunxi.git
     cd u-boot-sunxi
     git checkout -b sunxi-next origin/sunxi-next
 

--- a/data/wiki/xen-synthesize-virtual-disk.md
+++ b/data/wiki/xen-synthesize-virtual-disk.md
@@ -100,7 +100,7 @@ used for basic testing!
 Assuming that worked ok, clone and build the source for `xen-disk` yourself:
 
 ```
-  git clone git://github.com/mirage/xen-disk
+  git clone https://github.com/mirage/xen-disk
   cd xen-disk
   make
 ```


### PR DESCRIPTION
git:// URLs do not work anymore since 2021.
https://github.blog/2021-09-01-improving-git-protocol-security-github/