### PR TITLE
Update opam-repository commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ RUN mkdir -p /home/opam/www/mirage
 WORKDIR /home/opam/www
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && cd ~/opam-repository && git pull origin master && git reset --hard 55dda47191d1653dd3982ff54e964cb16428e775 && opam update
 RUN opam pin git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6
-RUN opam pin add git+https://github.com/mirage/mirage#8ab03cff7c811828d3e2e4473cbc0e55204652ec --with-version 4.0.0
 RUN opam repo add mirage-dev git+https://github.com/mirage/mirage-dev.git#842c55556ffd0950d21141d6ab99e52a8d88a50f
 RUN opam install mirage
 COPY --chown=opam:root mirage/config.ml /home/opam/www/mirage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-11-ocaml-4.13
 RUN mkdir -p /home/opam/www/mirage
 WORKDIR /home/opam/www
-RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && cd ~/opam-repository && git pull origin master && git reset --hard 1bcdfde9fb967edf419a456704134f0256641ad6 && opam update
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && cd ~/opam-repository && git pull origin master && git reset --hard 55dda47191d1653dd3982ff54e964cb16428e775 && opam update
 RUN opam pin git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6
 RUN opam pin add git+https://github.com/mirage/mirage#8ab03cff7c811828d3e2e4473cbc0e55204652ec --with-version 4.0.0
 RUN opam repo add mirage-dev git+https://github.com/mirage/mirage-dev.git#842c55556ffd0950d21141d6ab99e52a8d88a50f


### PR DESCRIPTION
Server has run out of memory. I'm proposing an update of the opam repository commit to integrate memory leak fixes in mirage-tcpip 7.1.2