### PR TITLE
fix date for security page

### DIFF
--- a/data/wiki/security.md
+++ b/data/wiki/security.md
@@ -1,5 +1,5 @@
 ---
-updated: 2019-14-26
+updated: 2019-04-26
 author:
   name: Amir Chaudhry
   uri: http://amirchaudhry.com


### PR DESCRIPTION
I'm pretty confused about two things:
- why can such a timestamp exist? isn't it used for e.g. the atom/rss feed (do we still have an atom/rss feed with the recent website updates?)
- is there a requirement for an author of a page? what is the meaning thereof (I understand it's nice for blog articles, but e.g. the security process / security page is basically written by the mirage core team, no?)

It also feels pretty strange to me to have dates in the "metadata", isn't it all stored in a git repository and couldn't git's data be used for figuring out a publishing and last update timestamp? as canopy did nearly a decade ago...