### PR TITLE
Blog posts: parse date

### DIFF
--- a/data/dune
+++ b/data/dune
@@ -2,12 +2,13 @@
  (name gen_data)
  (modules
   (:standard \ mirageio_data))
- (libraries omd yaml fmt)
+ (libraries omd yaml fmt ptime)
  (preprocess
   (pps ppx_deriving_yaml)))
 
 (library
  (name mirageio_data)
+ (libraries ptime)
  (modules mirageio_data))
 
 (rule

--- a/data/mirageio_data.mli
+++ b/data/mirageio_data.mli
@@ -4,7 +4,7 @@ end
 
 module Blog : sig
   type t = {
-    updated : string;
+    updated : Ptime.t;
     authors : People.t list;
     subject : string;
     permalink : string;

--- a/template/atom.eml
+++ b/template/atom.eml
@@ -5,7 +5,7 @@ let render ~blog_posts ~contributors ~last_update =
   <title>The MirageOS Blog</title>
   <subtitle>The MirageOS Blog on building functional operating systems</subtitle>
   <rights>All rights reserved by the author</rights>
-  <updated><%s last_update %></updated>
+  <updated><%s Ptime.to_rfc3339 last_update %></updated>
   <link rel="self" href="https://mirage.io/feed.xml" />
   <link rel="alternate" href="https://mirage.io/blog/" type="text/html" />
 
@@ -37,7 +37,7 @@ let render ~blog_posts ~contributors ~last_update =
     </author>
     <% ); %>
     <rights>All rights reserved by the author</rights>
-    <updated><%s item.updated %></updated>
+    <updated><%s Ptime.to_rfc3339 item.updated %></updated>
     <link rel="alternate" href="https://mirage.io/blog/<%s item.permalink %>" type="text/html" />
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">

--- a/template/blog.eml
+++ b/template/blog.eml
@@ -15,7 +15,7 @@ let render ~latest ~recent = Layout.render
       <div class="text-sm mt-2">
         By <%s! Component.people item.authors %>
         -
-        <span class="text-grey"><%s! item.updated %></span>
+        <span class="text-grey"><%s! Util.date_to_string item.updated %></span>
       </div>
       <div class="mt-2 prose prose-sm prose-pre:bg-primary max-h-72 text-ellipsis overflow-hidden">
         <%s! item.body %>

--- a/template/blog_inner.eml
+++ b/template/blog_inner.eml
@@ -7,7 +7,7 @@ let render (item : Mirageio_data.Blog.t) = Layout.render
   <p class="font-bold text-grey mt-2">
     By <%s! Component.people item.authors %>
     -
-    <%s! item.updated %>
+    <%s! Util.date_to_string item.updated %>
   </p>
 </div>
 <hr class="border-black" />

--- a/template/homepage.eml
+++ b/template/homepage.eml
@@ -104,7 +104,7 @@ let render ~blog_posts = Layout.render ~title:"Welcome to MirageOS" ~description
         <div class="items-center space-x-2">
           <img class="inline" src="/icon/speech-bubble.svg" alt="Speech Bubble Icon" />
           <a href="/blog/<%s item.permalink %>" class="link-blue"> <%s item.subject %> </a>
-          <span class="text-grey">(<%s! item.updated %>)</span>
+          <span class="text-grey">(<%s! Util.date_to_string item.updated %>)</span>
         </div>
         <% ); %>
         <div>

--- a/template/util.ml
+++ b/template/util.ml
@@ -1,0 +1,3 @@
+let date_to_string ptime =
+  let (year, month, day) = Ptime.to_date ptime in
+  Fmt.str "%04d-%02d-%02d" year month day


### PR DESCRIPTION
This PR adds code to parse the `updated` field and make sure it has the expected format (year-month-day). 
The internal type becomes `Ptime.t` to make sure we use a valid date.

Then it's serialized to RFC 3339 when used in the atom feed, or back to year-month-day for blog posts.

Partial fix to https://github.com/mirage/mirage-www/issues/783
https://github.com/mirage/mirage-www/issues/780