### PR TITLE
Typo in cross-compilation blog post: src doesn't exist

### DIFF
--- a/data/blog/2022-03-30.cross-compilation.md
+++ b/data/blog/2022-03-30.cross-compilation.md
@@ -65,7 +65,7 @@ While obtaining dependencies, let's start to investigate the Dune-related files.
 
 ## `dune` Files
 
-### `src/dune`
+### `./dune`
 
 `dune` files describe build rules and high-level operations so that the build system can obtain a global dependency graph and know about what's available to build. See [dune-files](https://dune.readthedocs.io/en/stable/dune-files.html#dune) for more information.
 
@@ -79,7 +79,7 @@ at the configuration stage (after calling `mirage configure`).
 Then the content is replaced by `(include dune.build)` if the configuration is successful.
 
 
-### `src/dune.config`
+### `./dune.config`
 
 ```
 (data_only_dirs duniverse)
@@ -95,7 +95,7 @@ Here, two things are happening. First, the `duniverse/` folder is declared as da
 
 Second, a `config` executable is declared. It contains the second stage of the configuration process, which is executed to generate `dune.build`, `dune-workspace`, and various other files required to build the unikernel.
 
-### `src/dune-workspace`
+### `./dune-workspace`
 
 The workspace declaration file is a single file at a Dune project's root and describes global settings for the project. See the [documentation](https://dune.readthedocs.io/en/stable/dune-files.html#dune-workspace).
 
@@ -133,9 +133,9 @@ An important fact about the compiler toolchain is that Dune derives the C compil
 ))
 ```
 
-### `src/dune.build`
+### `./dune.build`
 
-When configuration is done, this file is included by `src/dune`.
+When configuration is done, this file is included by `./dune`.
 
 1. The generated source code is imported along with the unikernel sources:
 ```
@@ -181,7 +181,7 @@ When configuration is done, this file is included by `src/dune`.
   (deps (alias_rec all)))
 ```
 
-### `src/dist/dune`
+### `./dist/dune`
 
 Once the unikernel is built, this rule describes how it's promoted back into the source tree that resides inside the `dist/` folder.
 ```


### PR DESCRIPTION
Fixes https://github.com/mirage/mirage-www/issues/750