### PR TITLE
Add support for building with Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1677106266,
-        "narHash": "sha256-nsujN0ZqX6GCfo7p93CCWFajWXMDDpnHP27emlZikTE=",
+        "lastModified": 1677153290,
+        "narHash": "sha256-yVUoJ1V/WMFC5ZtrWCTuma+sPBHkjewIGHpOvn7N6HU=",
         "owner": "RyanGibb",
         "repo": "hillingar",
-        "rev": "fb9c1eabece8c87a864a3d4bcc23cd2c6d24c57d",
+        "rev": "ae21693a50aa8267bc461b3a680cb93239191c0c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,273 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hillingar": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nix-filter": "nix-filter",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "opam-nix": [
+          "opam-nix"
+        ],
+        "opam-overlays": [
+          "opam-overlays"
+        ],
+        "opam-repository": [
+          "opam-repository"
+        ],
+        "opam2json": "opam2json"
+      },
+      "locked": {
+        "lastModified": 1677106266,
+        "narHash": "sha256-nsujN0ZqX6GCfo7p93CCWFajWXMDDpnHP27emlZikTE=",
+        "owner": "RyanGibb",
+        "repo": "hillingar",
+        "rev": "fb9c1eabece8c87a864a3d4bcc23cd2c6d24c57d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "RyanGibb",
+        "repo": "hillingar",
+        "type": "github"
+      }
+    },
+    "mirage-opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1659352118,
+        "narHash": "sha256-X/Tdlj/PYxcQg/1hcHXxdnDr5zLO22LohIudX+oT968=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3e1fff9ec0112fe5ec61ea7cc6d37c1720d865f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "3e1fff9",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677092149,
+        "narHash": "sha256-FWDw98KGktGY3cOGs0xB7/M28mFrQ6mScHLPSjF0PLs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d0c43b82f91b83aa4e294e4788916b2a38007e64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "opam-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_3",
+        "mirage-opam-overlays": "mirage-opam-overlays",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "opam-overlays": "opam-overlays",
+        "opam-repository": [
+          "opam-repository"
+        ],
+        "opam2json": "opam2json_2"
+      },
+      "locked": {
+        "lastModified": 1677010306,
+        "narHash": "sha256-SKT6CGUI7tk24h+dUJ047BnBIZJs5x95e51pEhnAeTg=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "b85e6abc99acb0c4a983d6436e9d753561cf3d27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
+    "opam-overlays_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675691830,
+        "narHash": "sha256-bnx5zhRXkfNC//utGd95w4lRhnxB+16RmDhLuwWbXc4=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "32449554934c5e5093235d3ba9468ae2be83f424",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677088801,
+        "narHash": "sha256-JGr909ZIReqwYd4Zi54qbkCA9GdxQQfY6Fk016dnfhM=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "1c4baa4d5c7cfeebc37f1f0b666f269db6b13078",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam2json": {
+      "inputs": {
+        "nixpkgs": [
+          "hillingar",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "opam2json_2": {
+      "inputs": {
+        "nixpkgs": [
+          "opam-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "hillingar": "hillingar",
+        "nixpkgs": "nixpkgs",
+        "opam-nix": "opam-nix",
+        "opam-overlays": "opam-overlays_2",
+        "opam-repository": "opam-repository"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -26,35 +26,6 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
         "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
@@ -62,7 +33,9 @@
     },
     "hillingar": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nix-filter": "nix-filter",
         "nixpkgs": [
           "nixpkgs"
@@ -76,7 +49,9 @@
         "opam-repository": [
           "opam-repository"
         ],
-        "opam2json": "opam2json"
+        "opam2json": [
+          "opam2json"
+        ]
       },
       "locked": {
         "lastModified": 1677153290,
@@ -142,16 +117,22 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "opam-overlays": "opam-overlays",
+        "opam-overlays": [
+          "opam-overlays"
+        ],
         "opam-repository": [
           "opam-repository"
         ],
-        "opam2json": "opam2json_2"
+        "opam2json": [
+          "opam2json"
+        ]
       },
       "locked": {
         "lastModified": 1677010306,
@@ -168,22 +149,6 @@
       }
     },
     "opam-overlays": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654162756,
-        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "type": "github"
-      }
-    },
-    "opam-overlays_2": {
       "flake": false,
       "locked": {
         "lastModified": 1675691830,
@@ -218,28 +183,6 @@
     "opam2json": {
       "inputs": {
         "nixpkgs": [
-          "hillingar",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
-        "owner": "tweag",
-        "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "opam2json",
-        "type": "github"
-      }
-    },
-    "opam2json_2": {
-      "inputs": {
-        "nixpkgs": [
-          "opam-nix",
           "nixpkgs"
         ]
       },
@@ -263,8 +206,9 @@
         "hillingar": "hillingar",
         "nixpkgs": "nixpkgs",
         "opam-nix": "opam-nix",
-        "opam-overlays": "opam-overlays_2",
-        "opam-repository": "opam-repository"
+        "opam-overlays": "opam-overlays",
+        "opam-repository": "opam-repository",
+        "opam2json": "opam2json"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,6 @@
     hillingar.inputs.opam-nix.follows = "opam-nix";
 
     # maintain different repositories to those pinned in upstream repositories
-    opam-nix.inputs.opam-repository.follows = "opam-repository";
-    hillingar.inputs.opam-repository.follows = "opam-repository";
-    hillingar.inputs.opam-overlays.follows = "opam-overlays";
     opam-repository = {
       url = "github:ocaml/opam-repository";
       flake = false;
@@ -18,12 +15,25 @@
       url = "github:dune-universe/opam-overlays";
       flake = false;
     };
+    opam-nix.inputs.opam-repository.follows = "opam-repository";
+    opam-nix.inputs.opam-overlays.follows = "opam-overlays";
+    hillingar.inputs.opam-repository.follows = "opam-repository";
+    hillingar.inputs.opam-overlays.follows = "opam-overlays";
 
     # follow this flake's nixpkgs
     # useful if pinning nixos system nixpkgs with
     #   `nix.registry.nixpkgs.flake = nixpkgs;`
     opam-nix.inputs.nixpkgs.follows = "nixpkgs";
     hillingar.inputs.nixpkgs.follows = "nixpkgs";
+
+    # deduplicate flakes
+    flake-utils.url = "github:numtide/flake-utils";
+    hillingar.inputs.flake-utils.follows = "flake-utils";
+    opam-nix.inputs.flake-utils.follows = "flake-utils";
+    opam2json.url = "github:tweag/opam2json";
+    opam2json.inputs.nixpkgs.follows = "nixpkgs";
+    hillingar.inputs.opam2json.follows = "opam2json";
+    opam-nix.inputs.opam2json.follows = "opam2json";
   };
 
   outputs = { self, nixpkgs, flake-utils, opam-nix, hillingar, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,96 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    opam-nix.url = "github:tweag/opam-nix";
+    hillingar.url = "github:RyanGibb/hillingar";
+
+    hillingar.inputs.opam-nix.follows = "opam-nix";
+
+    # maintain different repositories to those pinned in upstream repositories
+    opam-nix.inputs.opam-repository.follows = "opam-repository";
+    hillingar.inputs.opam-repository.follows = "opam-repository";
+    hillingar.inputs.opam-overlays.follows = "opam-overlays";
+    opam-repository = {
+      url = "github:ocaml/opam-repository";
+      flake = false;
+    };
+    opam-overlays = {
+      url = "github:dune-universe/opam-overlays";
+      flake = false;
+    };
+
+    # follow this flake's nixpkgs
+    # useful if pinning nixos system nixpkgs with
+    #   `nix.registry.nixpkgs.flake = nixpkgs;`
+    opam-nix.inputs.nixpkgs.follows = "nixpkgs";
+    hillingar.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, opam-nix, hillingar, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        opam-nix-lib = opam-nix.lib.${system};
+        query = {
+          # find non-trunk version https://github.com/tweag/opam-nix/issues/35
+          ocaml-base-compiler = "*";
+          mirage = "4.3.3";
+        };
+
+        devPackagesQuery = {
+          ocaml-lsp-server = "*";
+          ocamlformat = "*";
+        };
+        overlay = final: prev: {
+          # dream-httpaf is vendored in dream, so we don't detect dream's depdnancy on gluten and gluten's depenancy on ke
+          "dream-httpaf" = prev."dream-httpaf".overrideAttrs (oa: {
+            buildInputs = oa.buildInputs ++ [ prev.ke ];
+          });
+          # dream uses mirage-crypto-rng.wt, so we need mirage-crypto-rng.0.10.7 before lwt was split
+          "dream" = prev."dream".overrideAttrs (oa: {
+            buildInputs = oa.buildInputs ++ [ prev.mirage-crypto-rng ];
+          });
+        };
+        queryForOverlay = {
+          ke = "*";
+          mirage-crypto-rng = "0.10.7";
+        };
+        scope =
+          let scope = opam-nix-lib.buildOpamProject' { } ./. (query // devPackagesQuery // queryForOverlay); in
+          scope.overrideScope' overlay;
+
+        unikernelPkgs = let
+          mirage-nix = (hillingar.lib.${system});
+          inherit (mirage-nix) mkUnikernelPackages;
+        in
+          mkUnikernelPackages {
+            unikernelName = "www";
+            mirageDir = "mirage";
+            # depexts for ocaml-gmp
+            depexts = with pkgs; [ opam gnum4 ];
+            monorepoQuery = {
+              # isn't picked up by `opam admin list`
+              gmp = "*";
+
+              # workaround https://github.com/RyanGibb/hillingar/issues/3
+              ptime = "1.0.0+dune"; # ptime 1.1.0 doesn't have an overlay
+              omd = "1.3.2"; # omd.2.0.0 introduces a dependancy on non-dune uunf
+            };
+            inherit query;
+          } self;
+      in {
+        packages = { inherit scope; unikernel = unikernelPkgs; };
+
+        defaultPackage = self.packages.${system}.scope.mirageio-bin;
+
+        devShells.default =
+          let
+            devPackages = builtins.attrValues
+              (pkgs.lib.getAttrs (builtins.attrNames devPackagesQuery) scope);
+          in pkgs.mkShell {
+            inputsFrom = [ scope.mirageio-bin ];
+            buildInputs = devPackages;
+          };
+      }
+    );
+}

--- a/lib/dune
+++ b/lib/dune
@@ -6,6 +6,10 @@
 (rule
  (targets asset.ml asset.mli)
  (deps
+  ; Not specifying dependencies on main.css on purpose so we can skip the generation
+  ; of the CSS file if we only want to run the server.
+  ; Uncomment in development
+  ../asset/main.css
   (source_tree ../asset))
  (action
   (with-stdout-to

--- a/lib/dune
+++ b/lib/dune
@@ -6,10 +6,6 @@
 (rule
  (targets asset.ml asset.mli)
  (deps
-  ; Not specifying dependencies on main.css on purpose so we can skip the generation
-  ; of the CSS file if we only want to run the server.
-  ; Uncomment in development
-  ../asset/main.css
   (source_tree ../asset))
  (action
   (with-stdout-to


### PR DESCRIPTION
This PR adds support for building the project with [Nix](https://nixos.org/).

It supports building a binary program as well as a unikernel with https://github.com/tweag/opam-nix and https://github.com/RyanGibb/hillingar respectively.

To build a binary, one can use `$ nix build .` or `$ nix build .#scope.mirageio-bin`.

To build a unikernel `$ nix build .#unikernel.<target>`, e.g. `$ nix build .#unikernel.unix`.

One can also create a development environment from these derivations. So instead of a new user having to go through the manual process of creating an opam switch and installing all the dependencies (along with debugging steps that might arise with the pinned packages, vendored dependencies, and external system packages) they can just run `nix develop .#<derivation> -c <command>`, e.g. ``nix develop . -c codium `pwd` `` or `nix develop .#unikernel.unix -c dune build`.

I hope this will enable reproducible builds to help alleviate issues such as:
- https://github.com/mirage/mirage-www/issues/792
- https://github.com/mirage/mirage-www/issues/757