### PR TITLE
Fixed: the command to execute hello application

### DIFF
--- a/data/wiki/hello-world.md
+++ b/data/wiki/hello-world.md
@@ -302,7 +302,7 @@ To run your application, execute the binary — and observe the exciting log
 messages that our loop is generating:
 
 ```bash
-$ dist/hello
+$ ./dist/hello
 ```
 
 #### Building for Another Backend

--- a/data/wiki/hello-world.md
+++ b/data/wiki/hello-world.md
@@ -302,7 +302,7 @@ To run your application, execute the binary — and observe the exciting log
 messages that our loop is generating:
 
 ```bash
-$ ./hello
+$ dist/hello
 ```
 
 #### Building for Another Backend


### PR DESCRIPTION
Fixed the command for executing the hello application from "./hello" to "dist/hello",

Because:
- Running the "./hello"  shows "-bash: ./hello: No such file or directory".

Solution:
- changed from "./hello" to "dist/hello"

Now fixed ✅