### PR TITLE
Update to Dream.1.0.0~alpha5 plus dream-mirage fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ocaml/opam:debian-11-ocaml-4.13
+FROM ocaml/opam:debian-12-ocaml-4.14
+RUN sudo apt-get update && sudo apt-get install autoconf automake -y --no-install-recommends
 RUN mkdir -p /home/opam/www/mirage
 WORKDIR /home/opam/www
-RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && cd ~/opam-repository && git pull origin master && git reset --hard 67a3d729ae0a48d689cd3a6cf17fa41494a4cb72 && opam update
-RUN opam pin git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && cd ~/opam-repository && git pull origin master && git reset --hard 297ab9ebb38254eee222f5bb4365ae80baa9caa1 && opam update
+RUN opam pin git+https://github.com/tmattio/opam-tailwindcss#a4c0ee9b9a80d44c4a953b07dc29e4aa065adf57
 RUN opam repo add mirage-dev git+https://github.com/mirage/mirage-dev.git#842c55556ffd0950d21141d6ab99e52a8d88a50f
 RUN opam install mirage
 COPY --chown=opam:root mirage/config.ml /home/opam/www/mirage/

--- a/dune-project
+++ b/dune-project
@@ -32,16 +32,19 @@
  (description "Website infrastructure and content for mirage.io")
  (depends
   (ocaml
-   (>= 4.08.0))
+   (>= 4.14))
   dune
   dream
   dream-mirage
-  mirage-kv-mem
-  mirage-clock-unix
-  mirage-unix
+  (tcpip (>= 8.0))
+  (mirage-time (>= 3.0))
+  (mirage-kv-mem (>= 3.2.1))
+  (mirage-clock-unix (>= 3.0))
+  (mirage-unix (>= 5.0.0))
+  (ptime (>= 0.8.1))
   (tailwindcss :build)
   (crunch (and :build (>= 3.1.0)))
-  (omd :build)
+  (omd (and :build (< 2.0.0~alpha3)))
   (yaml :build)
   (fmt :build)
-  (ppx_deriving_yaml :build)))
+  (ppx_deriving_yaml (and :build (>= 0.2.1)))))

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -52,9 +52,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/mirage/mirage-www.git"
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"] # branch mirage-alpha4
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"]
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6"]
+  ["dream-pure.dev"    "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["dream.dev"         "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["dream-mirage.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["dream-httpaf.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#a4c0ee9b9a80d44c4a953b07dc29e4aa065adf57"]
 ]

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -21,19 +21,22 @@ homepage: "https://github.com/mirage/mirage-www"
 doc: "https://mirage.github.io/mirage-www/"
 bug-reports: "https://github.com/mirage/mirage-www/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14"}
   "dune" {>= "2.7"}
   "dream"
   "dream-mirage"
-  "mirage-kv-mem"
-  "mirage-clock-unix"
-  "mirage-unix"
+  "tcpip" {>= "8.0"}
+  "mirage-time" {>= "3.0"}
+  "mirage-kv-mem" {>= "3.2.1"}
+  "mirage-clock-unix" {>= "3.0"}
+  "mirage-unix" {>= "5.0.0"}
+  "ptime" {>= "0.8.1"}
   "tailwindcss" {build}
   "crunch" {build & >= "3.1.0"}
-  "omd" {build}
+  "omd" {build & < "2.0.0~alpha3"}
   "yaml" {build}
   "fmt" {build}
-  "ppx_deriving_yaml" {build}
+  "ppx_deriving_yaml" {build & >= "0.2.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/mirageio.opam.template
+++ b/mirageio.opam.template
@@ -1,7 +1,7 @@
 pin-depends: [
-  ["dream.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"] # branch master+mirage
-  ["dream-mirage.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"]
-  ["dream-pure.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"]
-  ["dream-httpaf.dev" "git+https://github.com/TheLortex/dream.git#8bd9b9aa0640d15a94b9610709bf9ee24d70e8f0"]
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#fb0f82edd09999f7be033ab1785ba5f6b60ed8f6"]
+  ["dream-pure.dev"    "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["dream.dev"         "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["dream-mirage.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["dream-httpaf.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
+  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#a4c0ee9b9a80d44c4a953b07dc29e4aa065adf57"]
 ]


### PR DESCRIPTION
The opam pins match those for `ocaml-matrix` and the Dockerfile updates are required for the deployability check on [deploy.mirage.io](https://deploy.mirage.io)