### PR TITLE
Update to Tailwind CSS 3.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN sudo apt-get update && sudo apt-get install autoconf automake -y --no-instal
 RUN mkdir -p /home/opam/www/mirage
 WORKDIR /home/opam/www
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && cd ~/opam-repository && git pull origin master && git reset --hard 297ab9ebb38254eee222f5bb4365ae80baa9caa1 && opam update
-RUN opam pin git+https://github.com/tmattio/opam-tailwindcss#a4c0ee9b9a80d44c4a953b07dc29e4aa065adf57
+RUN opam pin tailwindcss.dev https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz
 RUN opam repo add mirage-dev git+https://github.com/mirage/mirage-dev.git#842c55556ffd0950d21141d6ab99e52a8d88a50f
 RUN opam install mirage
 COPY --chown=opam:root mirage/config.ml /home/opam/www/mirage/

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -59,5 +59,5 @@ pin-depends: [
   ["dream.dev"         "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
   ["dream-mirage.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
   ["dream-httpaf.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#a4c0ee9b9a80d44c4a953b07dc29e4aa065adf57"]
+  ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
 ]

--- a/mirageio.opam.template
+++ b/mirageio.opam.template
@@ -3,5 +3,5 @@ pin-depends: [
   ["dream.dev"         "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
   ["dream-mirage.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
   ["dream-httpaf.dev"  "git+https://github.com/tmcgilchrist/dream.git#fcc20d00bf61a1c417aa38e18b62aa3d0962704e"]
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#a4c0ee9b9a80d44c4a953b07dc29e4aa065adf57"]
+  ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
 ]


### PR DESCRIPTION
Both opam and ocaml-ci support pinning tar.gz packages, which are lighter to download than the whole git history.