### PR TITLE
 Update examples in tutorial-lwt.md with current versions. Fix a couple of issues in text.

### DIFF
--- a/data/dune
+++ b/data/dune
@@ -8,6 +8,7 @@
 
 (library
  (name mirageio_data)
+ (public_name mirageio.data)
  (libraries ptime)
  (modules mirageio_data))
 

--- a/data/wiki/dune
+++ b/data/wiki/dune
@@ -1,0 +1,12 @@
+(mdx
+ (files tutorial-lwt.md)
+ (preludes files/tutorial-lwt/prelude.ml)
+ (libraries
+  lwt
+  mirage-time
+  duration
+  mirage
+  logs
+  randomconv
+  cstruct
+  mirage-random))

--- a/data/wiki/files/tutorial-lwt/dune
+++ b/data/wiki/files/tutorial-lwt/dune
@@ -1,0 +1,9 @@
+(executable
+ (name heads1)
+ (modules heads1)
+ (libraries mirage))
+
+(executable
+ (name echo_server)
+ (modules echo_server)
+ (libraries mirage))

--- a/data/wiki/files/tutorial-lwt/echo_server.ml
+++ b/data/wiki/files/tutorial-lwt/echo_server.ml
@@ -1,0 +1,7 @@
+open Mirage
+
+let main =
+  let packages = [ package "duration"; package ~max:"0.2.0" "randomconv" ] in
+  main ~packages "Unikernel.Echo_server" (time @-> random @-> job)
+
+let () = register "echo_server" [ main $ default_time $ default_random ]

--- a/data/wiki/files/tutorial-lwt/heads1.ml
+++ b/data/wiki/files/tutorial-lwt/heads1.ml
@@ -1,0 +1,6 @@
+open Mirage
+
+let main =
+  main ~packages:[ package "duration" ] "Unikernel.Heads1" (time @-> job)
+
+let () = register "heads1" [ main $ default_time ]

--- a/data/wiki/files/tutorial-lwt/prelude.ml
+++ b/data/wiki/files/tutorial-lwt/prelude.ml
@@ -1,0 +1,17 @@
+let foo () = failwith "foo"
+let read_arg _ = failwith "read_arg"
+let new_id () = Oo.id (object end)
+let on_response_to _ _ : unit = failwith "on_response_to"
+let send_request _ _ : unit = failwith "send_request"
+let pp_frame _ _ = failwith "pp_fram"
+let generate _ = failwith "generate"
+let get_input _ : int = 0
+let get_input_lwt _ : int Lwt.t = Lwt.return 0
+
+module Time : Mirage_time.S = struct
+  let sleep_ns _ : unit Lwt.t = failwith "Time.sleep_ns"
+end
+
+module R = struct
+  let generate n : Cstruct.t = failwith "R.generate"
+end

--- a/data/wiki/files/tutorial-lwt/timeout1.ml
+++ b/data/wiki/files/tutorial-lwt/timeout1.ml
@@ -1,0 +1,9 @@
+open Mirage
+
+let main =
+  main
+    ~packages:[ package "duration"; package ~max:"0.2.0" "randomconv" ]
+    "Unikernel.Timeout1"
+    (time @-> random @-> job)
+
+let () = register "timeout1" [ main $ default_time $ default_random ]

--- a/data/wiki/tutorial-lwt.md
+++ b/data/wiki/tutorial-lwt.md
@@ -26,7 +26,7 @@ The first useful function is `return`, which constructs a trivial, already-retur
 ```
 
 This is useful if an API requires a thread, but you already happen to know the value.
-Once the value is wrapped in its Lwt thread, it cannot directly be used (as in general a thread may not have terminated yet). This is where the `>>=` operator (pronounced "bind") comes in:
+Once the value is wrapped in its Lwt thread, it cannot directly be used (as in general a thread may not have terminated yet). This is where the `>>=` infix operator (pronounced "bind") comes in:
 
 ```ocaml
   val ( >>= ): 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t

--- a/data/wiki/tutorial-lwt.md
+++ b/data/wiki/tutorial-lwt.md
@@ -81,7 +81,7 @@ Two important functions to compose threads are `join` and `choose`.
 
 `choose l` behaves as the first thread in `l` to terminate. If several threads are already terminated, one is chosen at random.
 
-The [Lwt_list](https://ocsigen.org/lwt/5.1.2/api/Lwt_list) module provides many other functions for handling lists of threads.
+The [Lwt_list](https://ocsigen.org/lwt/latest/api/Lwt_list) module provides many other functions for handling lists of threads.
 
 ## Challenge 1: Sleep and join
 
@@ -533,7 +533,7 @@ Found in [lwt/tutorial/timeout2/unikernel.ml][timeout2_unikernel.ml] in the repo
 The `cancel` function should be used very sparingly, since it essentially throws an unexpected exception into the middle of some executing code that probably wasn't expecting it.
 A cancel that occurs when the thread happens to be performing an uncancellable operation will be silently ignored.
 
-A safer alternative is to use [Lwt_switch](https://ocsigen.org/lwt/5.1.2/api/Lwt_switch).
+A safer alternative is to use [Lwt_switch](https://ocsigen.org/lwt/latest/api/Lwt_switch).
 This means that cancellation will only happen at well defined points, although it does require explicit support from the code being cancelled.
 If you have a function that only responds to cancel, you might want to wrap it in a function that takes a switch and cancels it when the switch is turned off.
 

--- a/data/wiki/tutorial-lwt.md
+++ b/data/wiki/tutorial-lwt.md
@@ -8,15 +8,25 @@ subject: Getting Started with Lwt threads
 permalink: tutorial-lwt
 ---
 
-[Lwt](https://www.ocsigen.org/lwt) is a lightweight cooperative threading library for OCaml. A good way to understand Lwt and its use in MirageOS is to write some simple code. This document introduces the basic concepts and suggests programs to write. Code for all examples is in the `mirage-skeleton/tutorial/lwt/` [repository](https://github.com/mirage/mirage-skeleton/tree/master/tutorial/lwt).
+[Lwt](https://www.ocsigen.org/lwt) is a lightweight cooperative
+threading library for OCaml. A good way to understand Lwt and its use
+in MirageOS is to write some simple code. This document introduces the
+basic concepts and suggests programs to write. Code for all examples
+is in the `mirage-skeleton/tutorial/lwt/`
+[repository](https://github.com/mirage/mirage-skeleton/tree/master/tutorial/lwt).
 
 ## Basics
 
-The full Lwt manual is available [elsewhere](https://ocsigen.org/lwt), but the minimal stuff needed to get started is here.
+The full Lwt manual is available [elsewhere](https://ocsigen.org/lwt),
+but the minimal stuff needed to get started is here.
 
-The core type in Lwt is a "thread" (also known as a "promise" in some other systems).
-An `'a Lwt.t` is a thread that should produce a value of type `'a` (for example, an `int Lwt.t` should produce a single `int`).
-Initially a thread is _sleeping_ (the result is not yet known). At some point, it changes to be either _returned_ (with a value of type `'a`) or _failed_ (with an exception). Once returned or failed, a thread never changes state again.
+The core type in Lwt is a "thread" (also known as a "promise" in some
+other systems).  An `'a Lwt.t` is a thread that should produce a value
+of type `'a` (for example, an `int Lwt.t` should produce a single
+`int`).  Initially a thread is _sleeping_ (the result is not yet
+known). At some point, it changes to be either _returned_ (with a
+value of type `'a`) or _failed_ (with an exception). Once returned or
+failed, a thread never changes state again.
 
 Lwt provides a number of functions for working with threads.
 The first useful function is `return`, which constructs a trivial, already-returned thread:
@@ -25,18 +35,27 @@ The first useful function is `return`, which constructs a trivial, already-retur
   val return: 'a -> 'a Lwt.t
 ```
 
-This is useful if an API requires a thread, but you already happen to know the value.
-Once the value is wrapped in its Lwt thread, it cannot directly be used (as in general a thread may not have terminated yet). This is where the `>>=` infix operator (pronounced "bind") comes in:
+This is useful if an API requires a thread, but you already happen to
+know the value.  Once the value is wrapped in its Lwt thread, it
+cannot directly be used (as in general a thread may not have
+terminated yet). This is where the `>>=` infix operator (pronounced
+"bind") comes in:
 
 ```ocaml
   val ( >>= ): 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
 ```
 
-`t >>= f` creates a thread which first waits for thread `t` to return some value `x`, then behaves as the new thread `f x`. If `t` is a sleeping thread, then `t >>= f` will initially be a sleeping thread too. If `t` fails, then the resulting thread will fail with the same exception.
+`t >>= f` creates a thread which first waits for thread `t` to return
+some value `x`, then behaves as the new thread `f x`. If `t` is a
+sleeping thread, then `t >>= f` will initially be a sleeping thread
+too. If `t` fails, then the resulting thread will fail with the same
+exception.
 
-If you ignore the `Lwt.t` bits in the types above, you can see that `return` looks like the identity function and `>>=` looks like `|>` ("pipe" or "apply").
-You can convert any synchronous program into an equivalent Lwt-threaded one using just `>>=` and `return`.
-For example consider this code to input two values and add them:
+If you ignore the `Lwt.t` bits in the types above, you can see that
+`return` looks like the identity function and `>>=` looks like `|>`
+("pipe" or "apply").  You can convert any synchronous program into an
+equivalent Lwt-threaded one using just `>>=` and `return`.  For
+example consider this code to input two values and add them:
 
 ```ocaml
   let x =
@@ -54,7 +73,9 @@ Removing the `let ... in ...` syntax, we could also write:
     a + b
 ```
 
-If the `get_input` function's type is changed from `string -> int` to the threaded-equivalent, `string -> int Lwt.t`, then our example could be changed to:
+If the `get_input` function's type is changed from `string -> int` to
+the threaded-equivalent, `string -> int Lwt.t`, then our example could
+be changed to:
 
 ```ocaml
   let x =
@@ -63,25 +84,33 @@ If the `get_input` function's type is changed from `string -> int` to the thread
     Lwt.return (a + b)
 ```
 
-Note that the final result, `x`, is itself a thread now.
-Since we didn't change `+` to return a thread, we must wrap the result with `return` to give it the correct type.
+Note that the final result, `x`, is itself a thread now. Since we
+didn't change `+` to return a thread, we must wrap the result with
+`return` to give it the correct type.
 
-Of course, the reason for using Lwt is to write programs that do more than just behave like synchronous programs: we want to be doing multiple things at once, by composing threads in more ways than just "_a_ then _b_".
-Two important functions to compose threads are `join` and `choose`.
+Of course, the reason for using Lwt is to write programs that do more
+than just behave like synchronous programs: we want to be doing
+multiple things at once, by composing threads in more ways than just
+"_a_ then _b_".  Two important functions to compose threads are `join`
+and `choose`.
 
 ```ocaml
   val join : unit Lwt.t list -> unit Lwt.t
 ```
 
-`join` takes a list of threads and waits for all of them to terminate. If at least one thread fails then `join l` will fail with the same exception as the first to fail, after all threads terminate.
+`join` takes a list of threads and waits for all of them to
+terminate. If at least one thread fails then `join l` will fail with
+the same exception as the first to fail, after all threads terminate.
 
 ```ocaml
  val choose : 'a t list -> 'a t
 ```
 
-`choose l` behaves as the first thread in `l` to terminate. If several threads are already terminated, one is chosen at random.
+`choose l` behaves as the first thread in `l` to terminate. If several
+threads are already terminated, one is chosen at random.
 
-The [Lwt_list](https://ocsigen.org/lwt/latest/api/Lwt_list) module provides many other functions for handling lists of threads.
+The [Lwt_list](https://ocsigen.org/lwt/latest/api/Lwt_list) module
+provides many other functions for handling lists of threads.
 
 ## Challenge 1: Sleep and join
 
@@ -89,11 +118,13 @@ Now write a program that spins off two threads, each of which sleeps for some
 amount of time, say 1 and 2 seconds and then one prints "Heads", the other
 "Tails". After both have finished, it prints "Finished" and exits.
 
-To sleep for some number of nanoseconds use the function `sleep_ns` declared in the
-interface [Mirage_time.S](https://mirage.github.io/mirage-time/mirage-time/Mirage_time/module-type-S/index.html), and to print to
-the console use `Logs.info`. Note that `Mirage_time` is a Mirage-specific module; if you are
-using Lwt in another context, use `Lwt_unix.sleep` and `Lwt_io.write`. (You will
-also need to manually start the main event loop with `Lwt_main.run`.)
+To sleep for some number of nanoseconds use the function `sleep_ns`
+declared in the interface
+[Mirage_time.S](https://mirage.github.io/mirage-time/mirage-time/Mirage_time/module-type-S/index.html),
+and to print to the console use `Logs.info`. Note that `Mirage_time`
+is a Mirage-specific module; if you are using Lwt in another context,
+use `Lwt_unix.sleep` and `Lwt_io.write`. (You will also need to
+manually start the main event loop with `Lwt_main.run`.)
 
 For convenience, you'll likely want to also use the
 [Duration](https://github.com/hannesm/duration) library, which provides handy
@@ -136,7 +167,10 @@ Assuming you want to build as a normal Unix process, compile the application wit
   ./main.native
 ```
 
-If you prefer to build for another target (like `xen` or `hvt`), change the `-t` argument to `mirage configure`.  To see the available backends, have a look at the documentation available with `mirage configure --help`.
+If you prefer to build for another target (like `xen` or `hvt`),
+change the `-t` argument to `mirage configure`.  To see the available
+backends, have a look at the documentation available with `mirage
+configure --help`.
 
 ### Solution
 
@@ -156,13 +190,21 @@ module Heads1 (Time : Mirage_time.S) = struct
 end
 ```
 
-This code is also found in [tutorial/lwt/heads1/unikernel.ml][heads1_unikernel.ml] in the [mirage-skeleton](https://github.com/mirage/mirage-skeleton) code repository.  Build it with `mirage configure -t unix && make depend && make`, as described above.
+This code is also found in
+[tutorial/lwt/heads1/unikernel.ml][heads1_unikernel.ml] in the
+[mirage-skeleton](https://github.com/mirage/mirage-skeleton) code
+repository.  Build it with `mirage configure -t unix && make depend &&
+make`, as described above.
 
 ## Challenge 2: Looping echo server
 
-Write an echo server that reads from a dummy input generator and, for each line it reads, writes it to the console. The server should stop after reading 10 lines.
+Write an echo server that reads from a dummy input generator and, for
+each line it reads, writes it to the console. The server should stop
+after reading 10 lines.
 
-Hint: it's easier to convert a program to use Lwt if you write loops in a functional style (using tail recursion) rather than using special syntax (e.g. `while` and `for`).
+Hint: it's easier to convert a program to use Lwt if you write loops
+in a functional style (using tail recursion) rather than using special
+syntax (e.g. `while` and `for`).
 
 For convenience, here is a `config.ml` which you might use for this exercise:
 
@@ -176,7 +218,11 @@ let main =
 let () = register "echo_server" [ main $ default_time $ default_random ]
 ```
 
-You might notice that it's very similar to the previous example `config.ml`, but it requires an extra package `randomconv`.  `randomconv` has convenience functions for dealing with random data, which this challenge asks you to do.  Here is a basic dummy input generator you can use for testing:
+You might notice that it's very similar to the previous example
+`config.ml`, but it requires an extra package `randomconv`.
+`randomconv` has convenience functions for dealing with random data,
+which this challenge asks you to do.  Here is a basic dummy input
+generator you can use for testing:
 
 ```ocaml
   let read_line () =
@@ -184,8 +230,11 @@ You might notice that it's very similar to the previous example `config.ml`, but
     >|= fun () -> String.make (Randomconv.int ~bound:20 generate) 'a'
 ```
 
-By the way, the `>|=` operator ("map") used here is similar to `>>=` but automatically wraps the result of the function you provide with `return`. It's used here because `String.make` is synchronous (it doesn't return a thread). We could also have used `>>=` and `return` together to get the same effect.
-
+By the way, the `>|=` operator ("map") used here is similar to `>>=`
+but automatically wraps the result of the function you provide with
+`return`. It's used here because `String.make` is synchronous (it
+doesn't return a thread). We could also have used `>>=` and `return`
+together to get the same effect.
 
 ### Solution
 
@@ -234,7 +283,15 @@ event that will wake up the associated thread when possible.
 
 ## Mutexes and cooperation
 
-With Lwt, it is often possible to avoid mutexes altogether! The web server from the [Ocsigen](https://ocsigen.org) project uses only two, for example. In usual concurrent systems, mutexes are used to prevent two (or more) threads executing concurrently on a given piece of data. This can happen when a thread is preemptively interrupted and another one starts running. In Lwt, a thread executes serially until it explicitly yields (most commonly via `>>=`); for this reason, Lwt threads are said to be [cooperative](https://en.wikipedia.org/wiki/Cooperative_multitasking#Cooperative_multitasking.2Ftime-sharing).
+With Lwt, it is often possible to avoid mutexes altogether! The web
+server from the [Ocsigen](https://ocsigen.org) project uses only two,
+for example. In usual concurrent systems, mutexes are used to prevent
+two (or more) threads executing concurrently on a given piece of
+data. This can happen when a thread is preemptively interrupted and
+another one starts running. In Lwt, a thread executes serially until
+it explicitly yields (most commonly via `>>=`); for this reason, Lwt
+threads are said to be
+[cooperative](https://en.wikipedia.org/wiki/Cooperative_multitasking#Cooperative_multitasking.2Ftime-sharing).
 
 For example, consider this code to generate unique IDs:
 
@@ -246,10 +303,14 @@ let next =
     !i
 ```
 
-It is entirely safe to call this from multiple Lwt threads, since we know that `incr`, the only function we call, isn't going to somehow recursively call `next` while it's running.
+It is entirely safe to call this from multiple Lwt threads, since we
+know that `incr`, the only function we call, isn't going to somehow
+recursively call `next` while it's running.
 
-Calling `x >>= f` (and similar) will run other threads while waiting for `x` to terminate, and these may well invoke the function again, so you can't assume things won't be modified across a bind.
-For example, this version is _not_ safe:
+Calling `x >>= f` (and similar) will run other threads while waiting
+for `x` to terminate, and these may well invoke the function again, so
+you can't assume things won't be modified across a bind.  For example,
+this version is _not_ safe:
 
 ```ocaml
 let next =
@@ -260,11 +321,22 @@ let next =
     !i
 ```
 
-Of course, this is true of _any_ function that might, directly or indirectly, call `next`, not just Lwt ones.
+Of course, this is true of _any_ function that might, directly or
+indirectly, call `next`, not just Lwt ones.
 
-The obvious danger associated with cooperative threading is having threads not cooperating: if an expression takes a lot of time to compute with no cooperation point, then the whole program hangs. The `Lwt.yield` function introduces an explicit cooperation point. `sleep`ing also obviously makes the thread cooperate.
+The obvious danger associated with cooperative threading is having
+threads not cooperating: if an expression takes a lot of time to
+compute with no cooperation point, then the whole program hangs. The
+`Lwt.yield` function introduces an explicit cooperation
+point. `sleep`ing also obviously makes the thread cooperate.
 
-If locking a data structure is still needed, the `Lwt_mutex` module provides the necessary functions. To obtain more information on thread switching (and how to prevent it) read the Lwt mailing list archive: [Lwt_stream, thread switch within push function](https://sympa.inria.fr/sympa/arc/ocsigen/2011-09/msg00029.html) which continues [here](https://sympa.inria.fr/sympa/arc/ocsigen/2011-10/msg00001.html).
+If locking a data structure is still needed, the `Lwt_mutex` module
+provides the necessary functions. To obtain more information on thread
+switching (and how to prevent it) read the Lwt mailing list archive:
+[Lwt_stream, thread switch within push
+function](https://sympa.inria.fr/sympa/arc/ocsigen/2011-09/msg00029.html)
+which continues
+[here](https://sympa.inria.fr/sympa/arc/ocsigen/2011-10/msg00001.html).
 
 
 ## Spawning background threads
@@ -278,13 +350,20 @@ Lwt.async (fun () ->
 )
 ```
 
-**Note**: do _not_ do `let _ = my_background_thread ()`. This ignores the result of the thread, which means that if it fails with an exception then the error will never be reported.
+**Note**: do _not_ do `let _ = my_background_thread ()`. This ignores
+  the result of the thread, which means that if it fails with an
+  exception then the error will never be reported.
 
-`Lwt.async` reports errors to the user's configured `Lwt.async_exception_handler`, which may or may not terminate the unikernel depending on how it has been configured.
+`Lwt.async` reports errors to the user's configured
+`Lwt.async_exception_handler`, which may or may not terminate the
+unikernel depending on how it has been configured.
 
-It is often better to catch such exceptions and log them with some contextual information.
-Here's some real Mirage code that spawns a new background thread to handle a new frame received from the network.
-The log message includes the exception it caught, a dump of the troublesome frame and, like all log messages, information about when it occurred and in which module.
+It is often better to catch such exceptions and log them with some
+contextual information.  Here's some real Mirage code that spawns a
+new background thread to handle a new frame received from the network.
+The log message includes the exception it caught, a dump of the
+troublesome frame and, like all log messages, information about when
+it occurred and in which module.
 
 ```ocaml
 (* Handle a frame of data from the network... *)
@@ -299,8 +378,11 @@ Lwt.async (fun () ->
 )
 ```
 
-By the way, the reason `async` and `catch` take functions that create threads rather than just plain threads is so they can start the thread inside a `try .. with` block and so handle OCaml exceptions consistently.
-Be careful not to disable this safety feature by accident - consider:
+By the way, the reason `async` and `catch` take functions that create
+threads rather than just plain threads is so they can start the thread
+inside a `try .. with` block and so handle OCaml exceptions
+consistently.  Be careful not to disable this safety feature by
+accident - consider:
 
 ```ocaml
 let test1 () =
@@ -314,24 +396,34 @@ let test2 () =
     (fun ex -> print_endline "caught exception!"; Lwt.return ())
 ```
 
-Because `test1`'s `t` raises an exception immediately (without waiting for a sleeping thread and thus getting added to an event queue), `test1` will exit with an exception before even reaching the `catch` function.
+Because `test1`'s `t` raises an exception immediately (without waiting
+for a sleeping thread and thus getting added to an event queue),
+`test1` will exit with an exception before even reaching the `catch`
+function.
 
-However, `test2`'s `t` blocks first. In this case, the sleeping `t` is passed to `catch`, which handles the exception.
+However, `test2`'s `t` blocks first. In this case, the sleeping `t` is
+passed to `catch`, which handles the exception.
 
-Moving the `let t = ` inside the `catch` callback avoids this problem (as does using `Lwt.fail` instead of `raise`).
-
+Moving the `let t = ` inside the `catch` callback avoids this problem
+(as does using `Lwt.fail` instead of `raise`).
 
 ## Error handling
 
-In Mirage code, we typically distinguish two types of error: programming errors (bugs, which should be reported to the programmer to be fixed) and expected errors (e.g. network disconnected or invalid TCP packet received).
-We try to use the type system to ensure that expected errors are handled gracefully.
+In Mirage code, we typically distinguish two types of error:
+programming errors (bugs, which should be reported to the programmer
+to be fixed) and expected errors (e.g. network disconnected or invalid
+TCP packet received).  We try to use the type system to ensure that
+expected errors are handled gracefully.
 
 ### Use result for expected errors
 
-For expected errors, you should use the `result` type, which provides `Ok` and `Error` constructors.
-This is a built-in in OCaml 4.03 and available from the `result` opam package for older versions.
+For expected errors, you should use the `result` type, which provides
+`Ok` and `Error` constructors.  This is a built-in in OCaml 4.03 and
+available from the `result` opam package for older versions.
 
-Here's an example that calls `read_arg` twice and returns the sum of the results on success. If either `read_arg` returns an error then that is returned immediately.
+Here's an example that calls `read_arg` twice and returns the sum of
+the results on success. If either `read_arg` returns an error then
+that is returned immediately.
 
 ```ocaml
 let example () =
@@ -344,7 +436,8 @@ let example () =
   Lwt.return (Ok (a + b))
 ```
 
-It is often useful to provide some helpers to handle this pattern (using Lwt threads and result types together) more simply:
+It is often useful to provide some helpers to handle this pattern
+(using Lwt threads and result types together) more simply:
 
 ```ocaml
 let ok x = Lwt.return (Ok x)
@@ -362,11 +455,15 @@ let example () =
 
 ### Use raise or fail for bugs
 
-If a bug is detected, you should raise an exception. In threaded code you should use `Lwt.fail`, although Lwt will catch exceptions and turn them into failures automatically if you forget.
+If a bug is detected, you should raise an exception. In threaded code
+you should use `Lwt.fail`, although Lwt will catch exceptions and turn
+them into failures automatically if you forget.
 
 ### Catching exceptions
 
-You shouldn't normally need to catch specific exceptions (it would be better to use an `Error` return in that case), but it is sometimes necessary.
+You shouldn't normally need to catch specific exceptions (it would be
+better to use an `Error` return in that case), but it is sometimes
+necessary.
 
 The Lwt-equivalent of
 
@@ -389,8 +486,11 @@ is
 
 ### Finalize
 
-Depending on how the unikernel is set up, an exception may or may not be fatal.
-In general, if you allocate a resource that won't be automatically freed by the garbage collector then you should use `Lwt.finalize` to ensure it is cleaned up whether the function using it succeeds or not:
+Depending on how the unikernel is set up, an exception may or may not
+be fatal. In general, if you allocate a resource that won't be
+automatically freed by the garbage collector then you should use
+`Lwt.finalize` to ensure it is cleaned up whether the function using
+it succeeds or not:
 
 ```ocaml
   let r = Resource.alloc () in
@@ -399,7 +499,8 @@ In general, if you allocate a resource that won't be automatically freed by the 
     (fun () -> Resource.free r)
 ```
 
-To make it harder to get this wrong, it is a good idea to provide a `with_` function, so users can just do:
+To make it harder to get this wrong, it is a good idea to provide a
+`with_` function, so users can just do:
 
 ```ocaml
   with_resource (fun r -> use r)
@@ -408,8 +509,8 @@ To make it harder to get this wrong, it is a good idea to provide a `with_` func
 
 ## User-defined threads
 
-You can create a thread that sleeps until you explicitly make it return a result with `Lwt.wait`,
-which returns a thread and a _waker_:
+You can create a thread that sleeps until you explicitly make it
+return a result with `Lwt.wait`, which returns a thread and a _waker_:
 
 ```ocaml
 let invoke_remote msg =
@@ -420,12 +521,17 @@ let invoke_remote msg =
   t
 ```
 
-This is mainly useful when interacting with external processes (as in this example), or libraries that don't support Lwt directly.
+This is mainly useful when interacting with external processes (as in
+this example), or libraries that don't support Lwt directly.
 
 
 ## Cancelling
 
-In order to cancel a thread, the function `cancel` (provided by the module Lwt) is needed. It has type `'a t -> unit` and does exactly what it says (except on certain complicated cases that are not in the scope of this tutorial). A simple timeout function that cancels a thread after a given number of seconds can be written easily:
+In order to cancel a thread, the function `cancel` (provided by the
+module Lwt) is needed. It has type `'a t -> unit` and does exactly
+what it says (except on certain complicated cases that are not in the
+scope of this tutorial). A simple timeout function that cancels a
+thread after a given number of seconds can be written easily:
 
 ```ocaml
   (* In this example and all those afterwards, we consider Lwt and OS to be
@@ -436,11 +542,17 @@ In order to cancel a thread, the function `cancel` (provided by the module Lwt) 
 
 ### Challenge 3: Timeouts
 
-This `timeout` function does not allow one to use the result returned by the thread `t`.
+This `timeout` function does not allow one to use the result returned
+by the thread `t`.
 
-Modify the `timeout` function so that it returns either `None` if `t` has not yet returned after `delay` seconds or `Some v` if `t` returns `v` within `delay` seconds. In order to achieve this behaviour it is possible to use the function `Lwt.state` that, given a thread, returns the state it is in, either `Sleep`, `Return` or `Fail`.
+Modify the `timeout` function so that it returns either `None` if `t`
+has not yet returned after `delay` seconds or `Some v` if `t` returns
+`v` within `delay` seconds. In order to achieve this behaviour it is
+possible to use the function `Lwt.state` that, given a thread, returns
+the state it is in, either `Sleep`, `Return` or `Fail`.
 
-You can test your solution with this application, which creates a thread that may be cancelled before it returns:
+You can test your solution with this application, which creates a
+thread that may be cancelled before it returns:
 
 ```ocaml
   let start _time _r =
@@ -495,9 +607,12 @@ module Timeout1 (Time : Mirage_time.S) (R : Mirage_random.S) = struct
 end
 ```
 
-This solution and application are found in [tutorial/lwt/timeout1/unikernel.ml][timeout1_unikernel.ml] in the repository.
+This solution and application are found in
+[tutorial/lwt/timeout1/unikernel.ml][timeout1_unikernel.ml] in the
+repository.
 
-Does your solution match the one given here and always returns after `f` seconds, even when `t` returns within `delay` seconds?
+Does your solution match the one given here and always returns after
+`f` seconds, even when `t` returns within `delay` seconds?
 
 This is a good place to introduce a third operation to compose threads: `pick`.
 
@@ -505,14 +620,20 @@ This is a good place to introduce a third operation to compose threads: `pick`.
   val pick : 'a t list -> 'a t
 ```
 
-`pick` behaves exactly like `choose` except that it cancels all other sleeping threads when one terminates.
-
+`pick` behaves exactly like `choose` except that it cancels all other
+sleeping threads when one terminates.
 
 ### Challenge 4: Better timeouts
 
-In a typical use of a timeout, if `t` returns before the timeout has expired, one would want the timeout to be cancelled right away. The next challenge is to modify the timeout function to return `Some v` right after `t` returns. Of course if the timeout does expire then it should cancel `t` and return `None`.
+In a typical use of a timeout, if `t` returns before the timeout has
+expired, one would want the timeout to be cancelled right away. The
+next challenge is to modify the timeout function to return `Some v`
+right after `t` returns. Of course if the timeout does expire then it
+should cancel `t` and return `None`.
 
-In order to test your solution, you can compile it to a mirage executable and run it using the skeleton provided for the previous challenge.
+In order to test your solution, you can compile it to a mirage
+executable and run it using the skeleton provided for the previous
+challenge.
 
 
 ### Solution
@@ -526,25 +647,33 @@ In order to test your solution, you can compile it to a mirage executable and ru
     ]
 ```
 
-Found in [lwt/tutorial/timeout2/unikernel.ml][timeout2_unikernel.ml] in the repository.
+Found in [lwt/tutorial/timeout2/unikernel.ml][timeout2_unikernel.ml]
+in the repository.
 
 ### Warning
 
-The `cancel` function should be used very sparingly, since it essentially throws an unexpected exception into the middle of some executing code that probably wasn't expecting it.
-A cancel that occurs when the thread happens to be performing an uncancellable operation will be silently ignored.
+The `cancel` function should be used very sparingly, since it
+essentially throws an unexpected exception into the middle of some
+executing code that probably wasn't expecting it.  A cancel that
+occurs when the thread happens to be performing an uncancellable
+operation will be silently ignored.
 
-A safer alternative is to use [Lwt_switch](https://ocsigen.org/lwt/latest/api/Lwt_switch).
-This means that cancellation will only happen at well defined points, although it does require explicit support from the code being cancelled.
-If you have a function that only responds to cancel, you might want to wrap it in a function that takes a switch and cancels it when the switch is turned off.
+A safer alternative is to use
+[Lwt_switch](https://ocsigen.org/lwt/latest/api/Lwt_switch).  This
+means that cancellation will only happen at well defined points,
+although it does require explicit support from the code being
+cancelled.  If you have a function that only responds to cancel, you
+might want to wrap it in a function that takes a switch and cancels it
+when the switch is turned off.
 
 ## Other Lwt features
 
-Lwt provides many more features. See [the manual](https://ocsigen.org/lwt/) for details.
-However, the vast majority of code will only need the basic features described here.
+Lwt provides many more features. See [the
+manual](https://ocsigen.org/lwt/) for details. However, the vast
+majority of code will only need the basic features described here.
 
 [echo_server_unikernel.ml]: https://github.com/mirage/mirage-skeleton/blob/master/tutorial/lwt/echo_server/unikernel.ml
 [heads1_unikernel.ml]: https://github.com/mirage/mirage-skeleton/blob/master/tutorial/lwt/heads1/unikernel.ml
 [heads2_unikernel.ml]: https://github.com/mirage/mirage-skeleton/blob/master/tutorial/lwt/heads2/unikernel.ml
 [timeout1_unikernel.ml]: https://github.com/mirage/mirage-skeleton/blob/master/tutorial/lwt/timeout1/unikernel.ml
 [timeout2_unikernel.ml]: https://github.com/mirage/mirage-skeleton/blob/master/tutorial/lwt/timeout2/unikernel.ml
-

--- a/dune
+++ b/dune
@@ -9,5 +9,12 @@
   (action
    (chdir
     %{workspace_root}
-    (run tailwindcss build -c tailwind.config.js -i template/styles.css -o
-      %{target})))))
+    (run
+     tailwindcss
+     build
+     -c
+     tailwind.config.js
+     -i
+     template/styles.css
+     -o
+     %{target})))))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
-(lang dune 2.7)
+(lang dune 3.8)
+(using mdx 0.4)
 
 (name mirageio)
 
@@ -42,6 +43,8 @@
   (mirage-clock-unix (>= 3.0))
   (mirage-unix (>= 5.0.0))
   (ptime (>= 0.8.1))
+  (mdx :with-test)
+  (mirage :with-test)
   (tailwindcss :build)
   (crunch (and :build (>= 3.1.0)))
   (omd (and :build (< 2.0.0~alpha3)))

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,12 @@
 (library
- (name mirageio)
- (libraries dream-mirage mirage-time tcpip mirageio_template mirageio_data
-   mirage-kv-mem))
+ (public_name mirageio)
+ (libraries
+  dream-mirage
+  mirage-time
+  tcpip
+  mirageio_template
+  mirageio_data
+  mirage-kv-mem))
 
 (rule
  (targets asset.ml asset.mli)

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -22,7 +22,7 @@ doc: "https://mirage.github.io/mirage-www/"
 bug-reports: "https://github.com/mirage/mirage-www/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.8"}
   "dream"
   "dream-mirage"
   "tcpip" {>= "8.0"}
@@ -31,6 +31,8 @@ depends: [
   "mirage-clock-unix" {>= "3.0"}
   "mirage-unix" {>= "5.0.0"}
   "ptime" {>= "0.8.1"}
+  "mdx" {with-test}
+  "mirage" {with-test}
   "tailwindcss" {build}
   "crunch" {build & >= "3.1.0"}
   "omd" {build & < "2.0.0~alpha3"}

--- a/template/dune
+++ b/template/dune
@@ -1,5 +1,6 @@
 (library
  (name mirageio_template)
+ (public_name mirageio.template)
  (libraries dream-mirage mirageio_data))
 
 (rule


### PR DESCRIPTION
The examples in 'Getting Started with Lwt threads' tutorial on the website are outdated and do not compile on the current Mirage.
I have replaced the code with the current buildable versions from https://github.com/mirage/mirage-skeleton/tree/main/tutorial/lwt and edited the accompanying text where needed.

I also updated a couple of links to documentation in the text to the latest versions to be consistant and added a small clarifier.