### PR TITLE
Keep the URI targets in the http -> https redirections

### DIFF
--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -20,5 +20,6 @@ struct
     | Some domain ->
         WWW.Dream.(
           http ~port (Stack.tcp stack) @@ fun req ->
-          redirect ~status:`Moved_Permanently req domain)
+          let uri = domain ^ target req in
+          redirect ~status:`Moved_Permanently req uri)
 end

--- a/mirage/unikernel_tls.ml
+++ b/mirage/unikernel_tls.ml
@@ -115,8 +115,8 @@ struct
     let http =
       WWW.Dream.(
         http ~port:t.http_port (Stack.tcp stack) @@ fun req ->
-        redirect ~status:`Moved_Permanently req
-          ("https://" ^ Domain_name.to_string t.host))
+        let uri = "https://" ^ Domain_name.to_string t.host ^ target req in
+        redirect ~status:`Moved_Permanently req uri)
     in
     let https =
       match t.redirect with
@@ -124,7 +124,8 @@ struct
       | Some domain ->
           WWW.Dream.(
             https ~port:t.https_port (Stack.tcp stack) @@ fun req ->
-            redirect ~status:`Moved_Permanently req domain)
+            let uri = domain ^ target req in
+            redirect ~status:`Moved_Permanently req uri)
     in
     Lwt.join [ http; https ]
 end

--- a/mirage/unikernel_tls_local.ml
+++ b/mirage/unikernel_tls_local.ml
@@ -42,8 +42,8 @@ struct
     let http =
       WWW.Dream.(
         http ~port:http_port (Stack.tcp stack) @@ fun req ->
-        redirect ~status:`Moved_Permanently req
-          ("https://" ^ Domain_name.to_string host))
+        let uri = ("https://" ^ Domain_name.to_string host) ^ target req in
+        redirect ~status:`Moved_Permanently req uri)
     in
     let https =
       match redirect with
@@ -51,7 +51,8 @@ struct
       | Some domain ->
           WWW.Dream.(
             https ~port:https_port (Stack.tcp stack) @@ fun req ->
-            redirect ~status:`Moved_Permanently req domain)
+            let uri = domain ^ target req in
+            redirect ~status:`Moved_Permanently req uri)
     in
     Lwt.join [ http; https ]
 end


### PR DESCRIPTION
Tentative fix for #790

I've just tested locally the `unikernel.ml` one.