### PR TITLE
Support build with Mirage 4.5.1 and OCaml 5.2

### DIFF
--- a/.github/workflows/mirage.yml
+++ b/.github/workflows/mirage.yml
@@ -1,0 +1,34 @@
+name: Build the Mirage unikernel
+on: [push, pull_request]
+
+jobs:
+  mirage:
+    name: OCaml 5.2.0
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install OPAM and OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5.2.0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y libseccomp-dev
+          opam pin add -n ocaml-solo5 'https://github.com/shym/ocaml-solo5.git#ocaml-5.2-reb'
+          opam install mirage ocaml-solo5
+
+      - name: Build
+        run: |
+          rm Makefile # To let mirage create its custom Makefile instead
+          opam exec -- mirage configure -t hvt -f mirage/config.ml
+          opam exec -- make depend
+          opam exec -- dune build mirage/
+
+      - name: Query the built unikernel
+        run: |
+          opam exec -- solo5-elftool query-abi mirage/dist/www.hvt
+          opam exec -- solo5-elftool query-manifest mirage/dist/www.hvt

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ opam install "mirage>=4.0.0"
 Then, the unikernel can be _configured_:
 
 ```bash
+rm Makefile # To let mirage create its custom Makefile instead
 mirage configure -f mirage/config.ml -t <TARGET> ...
 ```
 

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -26,9 +26,7 @@ let tls_key =
   Key.(create "tls" Arg.(opt tls_conv No doc))
 
 let packages = [ package "mirageio"; package ~build:true "yaml" ]
-
-let packages_v =
-  Key.if_ Key.is_solo5 [ package ~scope:`Switch "solo5" ~max:"0.8.0" ] []
+let packages_v = Key.if_ Key.is_solo5 [ package ~scope:`Switch "solo5" ] []
 
 let https =
   let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel_tls.setup" ] in


### PR DESCRIPTION
This PR fixes the small details needed to build with Mirage 4.5.1 and OCaml 5.2, in part as a way to test the [PR to OCaml-Solo5] that brings support for 5.2. It comes with a CI configuration to make sure that it doesn’t build just by accident locally and also as a way to document the currently required workarounds:

- using a custom overlay repository for the `lwt_ppx` package until the [corresponding PR] is merged,
- pinning the `ocaml-solo5` package (obviously),

but I don’t know if we want to integrate that CI run (at least as is) into the repository.

This was tested briefly locally by launching the unikernel and visiting a couple of pages. Logs didn’t seem to contain anything unexpected.

[PR to OCaml-Solo5]: https://github.com/mirage/ocaml-solo5/pull/134
[corresponding PR]: https://github.com/dune-universe/opam-overlays/pull/214