### PR TITLE
Use variant-based bootvar for mdx

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   (mirage-net-unix :with-test)
   (mirage-logs :with-test)
   (mirage-crypto-rng-mirage :with-test)
-  (mirage-bootvar-unix :with-test)
+  (mirage-bootvar :with-test)
   (dns-certify :with-test)
   (lwt :with-test)
   (charrua-client :with-test)))

--- a/mirageio.opam
+++ b/mirageio.opam
@@ -45,7 +45,7 @@ depends: [
   "mirage-net-unix" {with-test}
   "mirage-logs" {with-test}
   "mirage-crypto-rng-mirage" {with-test}
-  "mirage-bootvar-unix" {with-test}
+  "mirage-bootvar" {with-test}
   "dns-certify" {with-test}
   "lwt" {with-test}
   "charrua-client" {with-test}


### PR DESCRIPTION
To avoid CI errors like [these](https://ocaml.ci.dev/github/mirage/mirage-www/commit/3589405f2f853b4b32209d968670284008fef815/variant/debian-12-5.2_opam-2.1#L788-788)