### PR TITLE
Reenable metrics for OCaml 5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ COPY --chown=opam:root mirage/config.ml /home/opam/www/mirage/
 COPY --chown=opam:root mirageio.opam /home/opam/www/
 ARG TARGET=unix
 ARG EXTRA_FLAGS=
-ARG EXTRA_FLAGS_NO_METRICS="--tls=true --separate-networks"
 RUN opam pin add -n ocaml-solo5 'https://github.com/shym/ocaml-solo5.git#ocaml-5.2-reb'
-RUN opam exec -- mirage configure -f mirage/config.ml -t $TARGET $EXTRA_FLAGS_NO_METRICS
+RUN opam pin add -n memtrace-mirage 'https://github.com/Firobe/memtrace-mirage.git'
+RUN opam exec -- mirage configure -f mirage/config.ml -t $TARGET $EXTRA_ARGS
 RUN opam exec -- make depend
 COPY --chown=opam:root . /home/opam/www
-RUN opam exec -- mirage configure -f mirage/config.ml -t $TARGET $EXTRA_FLAGS_NO_METRICS
+RUN opam exec -- mirage configure -f mirage/config.ml -t $TARGET $EXTRA_ARGS
 RUN opam exec -- dune build mirage/ --profile release
 RUN if [ $TARGET = hvt ]; then sudo cp mirage/dist/www.$TARGET /unikernel.$TARGET; fi


### PR DESCRIPTION
Use a version of `mirage-memtrace` compatible with OCaml 5.2 (mirroring similar changes on https://github.com/janestreet/memtrace/pull/22). The underlying `statmemprof` isn't available before 5.3, but this allows us to at least collect all the other stats in `mirage-monitoring` (including GC).

Now we can use the original Dockerfile, and just add pins for `ocaml-solo5` and `memtrace-mirage`. This also allows passing the same flags at runtime.