### PR TITLE
Fix github.com/robur-coop links

### DIFF
--- a/data/blog/2019-spring-retreat-roundup.md
+++ b/data/blog/2019-spring-retreat-roundup.md
@@ -11,7 +11,7 @@ permalink: 2019-spring-retreat-roundup
 Early March 2019, 31 MirageOS hackers gathered again in Marrakesh for our bi-annual hack retreat. We'd like to thank our amazing hosts, and everyone who participated on-site or remotely, and especially those who wrote up their experiences.
 <img src="/graphics/spring2019.jpg" style="glot:right; padding: 15px" />
 
-On this retreat, we ate our own dogfood, and used our MirageOS [DHCP](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp), [recursive DNS resolver](https://github.com/roburio/unikernels/tree/master/resolver), and [CalDAV](https://github.com/roburio/caldav) unikernels as isolated virtual machines running on a [PC Engines APU](https://pcengines.ch/apu2c4.htm) with [FreeBSD](https://freebsd.org) as host system. The CalDAV server persisted its data in a git repository on the host system, using the raw git protocol for communication, the smart HTTP protocol could have been used as well. Lynxis wrote a [detailed blog post about our uplink situation](https://lunarius.fe80.eu/blog/mirageos-2019.html).
+On this retreat, we ate our own dogfood, and used our MirageOS [DHCP](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp), [recursive DNS resolver](https://github.com/robur-coop/unikernels/tree/master/resolver), and [CalDAV](https://github.com/robur-coop/caldav) unikernels as isolated virtual machines running on a [PC Engines APU](https://pcengines.ch/apu2c4.htm) with [FreeBSD](https://freebsd.org) as host system. The CalDAV server persisted its data in a git repository on the host system, using the raw git protocol for communication, the smart HTTP protocol could have been used as well. Lynxis wrote a [detailed blog post about our uplink situation](https://lunarius.fe80.eu/blog/mirageos-2019.html).
 
 Lots of interesting discussions took place, code was developed, knowledge was exchanged, and issues were solved while we enjoyed the sun and the Moroccan food. The following list is not exhaustive, but gives an overview what was pushed forward.
 
@@ -100,7 +100,7 @@ The ixy network driver supports Intel 82599 network interface cards, and [is imp
 
 ## DNS client API
 
-Our proposed API is [described here](https://github.com/roburio/udns/blob/09c5e3c74c92505ec97f2a16818cc8a030e2868f/client/udns_client_flow.mli#L53-L80). Unix, Lwt, and MirageOS implementations are already available.
+Our proposed API is [described here](https://github.com/robur-coop/udns/blob/09c5e3c74c92505ec97f2a16818cc8a030e2868f/client/udns_client_flow.mli#L53-L80). Unix, Lwt, and MirageOS implementations are already available.
 
 ## [mirage-http](https://github.com/mirage/mirage-http) unified HTTP API
 

--- a/data/blog/2022-04-01.Mr-MIME.md
+++ b/data/blog/2022-04-01.Mr-MIME.md
@@ -263,9 +263,9 @@ The SMTP stack is pretty complex, but any of these unikernels can be used separa
 [Mailgun]: https://www.mailgun.com/
 [Sendgrid]: https://sendgrid.com/
 [Irmin]: https://github.com/mirage/irmin
-[`albatross`]: https://github.com/roburio/albatross
+[`albatross`]: https://github.com/robur-coop/albatross
 [`ocurrent`]: https://github.com/ocurrent/ocurrent
-[dns-primary-git]: https://github.com/roburio/dns-primary-git
+[dns-primary-git]: https://github.com/robur-coop/dns-primary-git
 [DNS resolver]: https://github.com/mirage/dns-resolver
 [multipart_form]: https://github.com/dinosaure/multipart_form
 [`ptt`]: https://github.com/mirage/ptt

--- a/data/blog/2022-04-08.robur.md
+++ b/data/blog/2022-04-08.robur.md
@@ -17,7 +17,7 @@ Robur started the development of [OpenVPN](https://openvpn.net/), a virtual priv
 
 We created OpenVPN as a MirageOS unikernel to forward all traffic to a single IP address or local network NAT through the OpenVPN tunnel. To increase security even further, we designed a fail-safe that dropped all packets (rather than sending them unencrypted) when the OpenVPN tunnel was down.
 
-This project was funded by [Prototype Fund](https://prototypefund.de) in 2019. The [code is available on GitHub](https://github.com/roburio/openvpn).
+This project was funded by [Prototype Fund](https://prototypefund.de) in 2019. The [code is available on GitHub](https://github.com/robur-coop/openvpn).
 
 ### CalDAV
 
@@ -29,7 +29,7 @@ CalDAV also comes with some client control with its ability to be tracked and re
 
 Robur’s tests of the basic tasks for maintaining a digital calendar, like adding or modifying an event, have all successfully passed with several different CalDAV clients, but we hope to develop CalDAV further by adding notifications on updates via email and integrating an address book. If you’re interested in donating or investing in CalDAV, please contact us through [our website](https://robur.coop/).
 
-The code for [CalDAV](https://github.com/roburio/caldav) is also released to `opam-repository`; the code for [CardDAV](https://git.robur.coop/linse/carddav) is not yet integrated nor released.
+The code for [CalDAV](https://github.com/robur-coop/caldav) is also released to `opam-repository`; the code for [CardDAV](https://git.robur.coop/linse/carddav) is not yet integrated nor released.
 
 ### DNS Projects
 
@@ -37,9 +37,9 @@ Robur engineers have created robust DNS Projects, like our [‘Let’s Encrypt�
 
 Robur’s authoritative DNS server delegates responsibility for a specific domain and provides mapping information for it, ensuring that the user gets to the correct IP address. At the other end of the process, Robur’s DNS resolver finds the exact server to handle the user’s request. To keep the codebase minimal for security and simplicity, we included only the elements absolutely necessary. The 'Let's Encrypt' unikernel waits for certificate requests in the zones (encoded as TLSA records), and uses a 'Let's Encrypt' DNS challenge to have these signed to certificates, again stored in the zones. Of course, certificates expiring soon will be updated by `dns-letsencrypt-secondary`. This unikernel does not need any persistent storage, as it leaves this to the `dns-primary-git`.
 
-We’ve been developing these DNS projects since 2017, and they serve a multitude of functions in the Robur ecosystem. Our domains (like nqsb.io and robur.coop) use our DNS server as an authoritative server, and we also use a caching resolver for our biannual [MirageOS retreats](http://retreat.mirage.io) in Marrakech. Additionally, any MirageOS unikernel can use our client to resolve domain names - using the dns-client devices, or [`happy-eyeballs`](https://github.com/roburio/happy-eyeballs), so it’s also beneficial to the OCaml community at large. Robur uses expressive OCaml types (GADT), so we can ensure a given query has a specific shape, like an address record query results in a set of IPv4 addresses.
+We’ve been developing these DNS projects since 2017, and they serve a multitude of functions in the Robur ecosystem. Our domains (like nqsb.io and robur.coop) use our DNS server as an authoritative server, and we also use a caching resolver for our biannual [MirageOS retreats](http://retreat.mirage.io) in Marrakech. Additionally, any MirageOS unikernel can use our client to resolve domain names - using the dns-client devices, or [`happy-eyeballs`](https://github.com/robur-coop/happy-eyeballs), so it’s also beneficial to the OCaml community at large. Robur uses expressive OCaml types (GADT), so we can ensure a given query has a specific shape, like an address record query results in a set of IPv4 addresses.
 
-Robur's DNS implementation can process extensions like dynamic updates, notifications, zone transfers, and request authentications. It can be installed through opam, as all OCaml tools and libraries. You can find our DNS code’s [library](https://github.com/mirage/ocaml-dns) and unikernels ([`dns-primary-git`](https://github.com/roburio/dns-primary-git), [`dns-secondary`](https://github.com/roburio/dns-secondary), [`dns-letsencrypt`](https://github.com/roburio/dns-letsencrypt-secondary), and [`dns-resolver`](https://git.robur.coop/robur/dns-resolver)) on GitHub.
+Robur's DNS implementation can process extensions like dynamic updates, notifications, zone transfers, and request authentications. It can be installed through opam, as all OCaml tools and libraries. You can find our DNS code’s [library](https://github.com/mirage/ocaml-dns) and unikernels ([`dns-primary-git`](https://github.com/robur-coop/dns-primary-git), [`dns-secondary`](https://github.com/robur-coop/dns-secondary), [`dns-letsencrypt`](https://github.com/robur-coop/dns-letsencrypt-secondary), and [`dns-resolver`](https://git.robur.coop/robur/dns-resolver)) on GitHub.
 
 Read further posts on [DNS from 2018](https://hannes.robur.coop/Posts/DNS), [DNS and CalDAV from 2019](https://hannes.robur.coop/Posts/Summer2019), [deploying authoritative DNS servers as unikernels (2019)](https://hannes.robur.coop/Posts/DnsServer), [reproducible builds (2019)](https://hannes.robur.coop/Posts/ReproducibleOPAM), [albatross (2017)](https://hannes.robur.coop/Posts/VMM), [deployment (2021)](https://hannes.robur.coop/Posts/Deploy),
 [builder-web (2022)](https://reynir.dk/posts/2022-03-08-builder-web.html), [visualizations (2022)](https://r7p5.earth/blog/2022-3-7/Builder-web%20visualizations%20at%20Robur), and [monitoring (2022)](https://hannes.robur.coop/Posts/Monitoring).

--- a/data/blog/2022-11-07.retreat.md
+++ b/data/blog/2022-11-07.retreat.md
@@ -21,7 +21,7 @@ We plan to have again more regular retreats in the future, they will be announce
 
 Once again we used a 4G modem as uplink. One gigabyte of data was 10 Dirham (roughly one Euro), which we collected when the data volume was close to being exceeded. The 4G connectivity was much better than in Marrakesh, likely due to less congestion on the countryside. An APU (tiny x86 computer from [PC Engines APU](https://www.pcengines.ch/apu.htm) with a serial connection) running [FreeBSD](https://freebsd.org) was at the heart of our network: the 4G modem was connected via USB, and some TP link access points for wireless connectivity. The routing and network address translation (NAT), which allowed all the laptops and mobile phones to connect to the Internet via the 4G modem was done by the FreeBSD host system (due to lack of a unikernel just doing this, something to prepare for the next event).
 
-For network address configuration and domain name resolution we used [DNS Vizor, a MirageOS unikernel](https://github.com/roburio/dnsvizor/tree/main/dns-and-dhcp) on the FreeBSD system with [solo5 hvt](https://github.com/solo5/solo5). We also deployed two other MirageOS unikernels: a local [bob](https://github.com/dinosaure/bob) relay for sharing files, and used a local [opam mirror](https://hannes.robur.coop/Posts/OpamMirror) to reduce our bandwidth use.
+For network address configuration and domain name resolution we used [DNS Vizor, a MirageOS unikernel](https://github.com/robur-coop/dnsvizor/tree/main/dns-and-dhcp) on the FreeBSD system with [solo5 hvt](https://github.com/solo5/solo5). We also deployed two other MirageOS unikernels: a local [bob](https://github.com/dinosaure/bob) relay for sharing files, and used a local [opam mirror](https://hannes.robur.coop/Posts/OpamMirror) to reduce our bandwidth use.
 
 While the retreat developed, the DNS resolution was not very stable since the resolver on the 4G modem was sometimes overloaded by lots of requests via a single TCP connection. In the first days we developed [UDP support for the MirageOS dns-client](https://github.com/mirage/ocaml-dns/pull/322) and the local connectivity experience greatly improved.
 
@@ -59,7 +59,7 @@ Based on [gilbraltar](https://github.com/dinosaure/gilbraltar) (which [now works
 
 #### HTTP client for MirageOS
 
-The earlier mentioned opam mirror contained a HTTP client (using HTTP/AF and H2, supporting both HTTP1 and HTTP2 and also IPv4 and IPv6) to download archives - and we had similar code in other projects. That's why we decided to [create the http-mirage-client opam package](https://github.com/roburio/http-mirage-client) to reuse that code.
+The earlier mentioned opam mirror contained a HTTP client (using HTTP/AF and H2, supporting both HTTP1 and HTTP2 and also IPv4 and IPv6) to download archives - and we had similar code in other projects. That's why we decided to [create the http-mirage-client opam package](https://github.com/robur-coop/http-mirage-client) to reuse that code.
 
 #### DNS resolver with filtering advertisement
 
@@ -67,11 +67,11 @@ This package is already picked up and used by [Mirage Hole](https://github.com/j
 
 #### Albatross meets NixOS
 
-[Albatross](https://github.com/roburio/albatross) is an orchestration system for MirageOS unikernels using solo5 (spt or hvt). Apart from console output, statistics, and resource policies, it supports remote management using TLS. Now albatross [supports NixOS](https://github.com/roburio/albatross/pull/120) and there is a [tutorial](https://github.com/Julow/albatross-nixos-example) how to set it up. Read [further in Tarides blog](https://tarides.com/blog/2022-10-28-the-mirageos-retreat-a-journey-of-food-cats-and-unikernels#deploying-albatross-on-nixos-no-more-iptables-debugging).
+[Albatross](https://github.com/robur-coop/albatross) is an orchestration system for MirageOS unikernels using solo5 (spt or hvt). Apart from console output, statistics, and resource policies, it supports remote management using TLS. Now albatross [supports NixOS](https://github.com/robur-coop/albatross/pull/120) and there is a [tutorial](https://github.com/Julow/albatross-nixos-example) how to set it up. Read [further in Tarides blog](https://tarides.com/blog/2022-10-28-the-mirageos-retreat-a-journey-of-food-cats-and-unikernels#deploying-albatross-on-nixos-no-more-iptables-debugging).
 
 #### Memory leaks
 
-We chased some memory leaks on this website, using [Grafana](https://grafana.com/) and [mirage-monitoring](https://github.com/roburio/mirage-monitoring). This lead to a [PR in paf](https://github.com/dinosaure/paf-le-chien/pull/72). We are still investigating another [memory issue](https://github.com/mirage/mirage-tcpip/issues/499). Read [further details in Tarides blog](https://tarides.com/blog/2022-10-28-the-mirageos-retreat-a-journey-of-food-cats-and-unikernels#monitoring-mirageio-and-chasing-memory-leaks).
+We chased some memory leaks on this website, using [Grafana](https://grafana.com/) and [mirage-monitoring](https://github.com/robur-coop/mirage-monitoring). This lead to a [PR in paf](https://github.com/dinosaure/paf-le-chien/pull/72). We are still investigating another [memory issue](https://github.com/mirage/mirage-tcpip/issues/499). Read [further details in Tarides blog](https://tarides.com/blog/2022-10-28-the-mirageos-retreat-a-journey-of-food-cats-and-unikernels#monitoring-mirageio-and-chasing-memory-leaks).
 
 #### Opam cache
 

--- a/data/blog/announcing-mirage-310-release.md
+++ b/data/blog/announcing-mirage-310-release.md
@@ -32,7 +32,7 @@ Some parts of the Mirage_key module were unified as well:
 - V6.network and V6.gateway are available, mirroring the V4 submodule
 
 If you're ready to experiment with the dual stack: below is a diff for our basic network example (from mirage-skeleton/device-usage/network) replacing IPv4 with a dual stack, and the tlstunnel unikernel commit
-https://github.com/roburio/tlstunnel/commit/2cb3e5aa11fca4b48bb524f3c0dbb754a6c8739b
+https://github.com/robur-coop/tlstunnel/commit/2cb3e5aa11fca4b48bb524f3c0dbb754a6c8739b
 changed tlstunnel from IPv4 stack to dual stack.
 
 ```diff

--- a/data/blog/announcing-mirage-35-release.md
+++ b/data/blog/announcing-mirage-35-release.md
@@ -31,7 +31,7 @@ The 3.5.0 release contains several API improvements of different MirageOS interf
 
 ### [Key-value store](https://github.com/mirage/mirage-kv)
 
-We improved the key-value store API, and added a read-write store. There is also [ongoing work](https://github.com/mirage/irmin/pull/559) which implements the read-write interface using irmin, a branchable persistent storage that can communicate via the git protocol. Motivations for these changes were the development of [CalDAV](https://github.com/roburio/caldav), but also the development of [wodan](https://github.com/mirage/wodan), a flash-friendly, safe and flexible filesystem. The goal is to EOL the [mirage-fs](https://github.com/mirage/mirage-fs) interface in favour of the key-value store.
+We improved the key-value store API, and added a read-write store. There is also [ongoing work](https://github.com/mirage/irmin/pull/559) which implements the read-write interface using irmin, a branchable persistent storage that can communicate via the git protocol. Motivations for these changes were the development of [CalDAV](https://github.com/robur-coop/caldav), but also the development of [wodan](https://github.com/mirage/wodan), a flash-friendly, safe and flexible filesystem. The goal is to EOL the [mirage-fs](https://github.com/mirage/mirage-fs) interface in favour of the key-value store.
 
 Major API improvements (in [this PR](https://github.com/mirage/mirage-kv/pull/14), since 2.0.0):
 - The `key` is now a path (list of segments) instead of a `string`

--- a/data/blog/announcing-mirage-40.md
+++ b/data/blog/announcing-mirage-40.md
@@ -16,13 +16,13 @@ project’s initial aim was to self-host as many services as possible
 aimed at empowering internet users to deploy infrastructure securely
 to own their data and take back control of their privacy. MirageOS can
 securely deploy [static website
-hosting](https://github.com/roburio/unipi) with “Let’s Encrypt”
+hosting](https://github.com/robur-coop/unipi) with “Let’s Encrypt”
 certificate provisioning and a [secure SMTP
 stack](https://github.com/mirage/ptt) with security
 extensions. MirageOS can also deploy decentralised communication
 infrastructure like [Matrix](https://github.com/mirage/ocaml-matrix),
-[OpenVPN servers](https://github.com/roburio/openvpn), and [TLS
-tunnels](https://github.com/roburio/tlstunnel) to ensure data privacy
+[OpenVPN servers](https://github.com/robur-coop/openvpn), and [TLS
+tunnels](https://github.com/robur-coop/tlstunnel) to ensure data privacy
 or [DNS(SEC) servers](https://github.com/mirage/ocaml-dns) for better
 authentication.
 
@@ -67,7 +67,7 @@ upgrading). You would also want to read [the complete list of API
 changes](https://mirage.io/docs/breaking-changes). You can see
 unikernel examples in
 [mirage/mirage-skeleton](https://github.com/mirage/mirage-skeleton),
-[roburio/unikernels](https://github.com/roburio/unikernels) or
+[robur-coop/unikernels](https://github.com/robur-coop/unikernels) or
 [tarides/unikernels](https://github.com/tarides/unikernels).
 
 ## About MirageOS

--- a/data/blog/deploying-mirageos-robur.md
+++ b/data/blog/deploying-mirageos-robur.md
@@ -13,7 +13,7 @@ permalink: deploying-mirageos-robur
 
 We are pleased to announce that the EU [NGI Pointer](https://pointer.ngi.eu) funding received by [robur](https://robur.coop) in 2021 lead to improved operations for MirageOS unikernels.
 
-Our main achievement are [reproducible binary builds](https://builds.robur.coop) of opam packages, including MirageOS unikernels and system packages. The infrastructure behind it, [orb](https://github.com/roburio/orb), [builder](https://github.com/roburio/builder), [builder-web](https://github.com/roburio/builder-web) is itself reproducible and delivered as packages by [builds.robur.coop](https://builds.robur.coop).
+Our main achievement are [reproducible binary builds](https://builds.robur.coop) of opam packages, including MirageOS unikernels and system packages. The infrastructure behind it, [orb](https://github.com/robur-coop/orb), [builder](https://github.com/robur-coop/builder), [builder-web](https://github.com/robur-coop/builder-web) is itself reproducible and delivered as packages by [builds.robur.coop](https://builds.robur.coop).
 
 The documentation how to get started [installing MirageOS unikernels and albatross from packages](https://robur.coop/Projects/Reproducible_builds) is available online, further documentation on [monitoring](https://hannes.robur.coop/Posts/Monitoring) is available as well.
 
@@ -24,7 +24,7 @@ The funding proposal covered the parts (as outlined in [an earlier post from 202
 
 We [announced the web interface earlier](https://discuss.ocaml.org/t/ann-robur-reproducible-builds/8827) and also [posted about deployment](https://hannes.robur.coop/Posts/Deploy) possibilities.
 
-At the heart of our infrastructure is [builder-web](https://github.com/roburio/builder-web), a database that receives binary builds and provides a web interface and binary package repositories ([apt.robur.coop](https://apt.robur.coop) and [pkg.robur.coop](https://pkg.robur.coop)). Reynir discusses the design and implementation of [builder-web](https://github.com/roburio/builder-web) in [his blogpost](https://reyn.ir/posts/2022-03-08-builder-web.html).
+At the heart of our infrastructure is [builder-web](https://github.com/robur-coop/builder-web), a database that receives binary builds and provides a web interface and binary package repositories ([apt.robur.coop](https://apt.robur.coop) and [pkg.robur.coop](https://pkg.robur.coop)). Reynir discusses the design and implementation of [builder-web](https://github.com/robur-coop/builder-web) in [his blogpost](https://reyn.ir/posts/2022-03-08-builder-web.html).
 
 There we [visualize](https://builds.robur.coop/job/tlstunnel/build/7f0afdeb-0a52-4de1-b96f-00f654ce9249/) the opam dependencies of an opam package:
 

--- a/lib/mirageio.ml
+++ b/lib/mirageio.ml
@@ -85,7 +85,7 @@ struct
   end
 
   module Last_modified = struct
-    (* https://github.com/roburio/unipi/blob/main/unikernel.ml *)
+    (* https://github.com/robur-coop/unipi/blob/main/unikernel.ml *)
     let ptime_to_http_date ptime =
       let (y, m, d), ((hh, mm, ss), _) = Ptime.to_date_time ptime
       and weekday =


### PR DESCRIPTION
The roburio GitHub organization was renamed to robur-coop to reflect the domain change. The change was done with a sed script and manually verified with git diff.

```sh
git grep -l roburio | xargs sed -i s/roburio/robur-coop/g
```