### PR TITLE
The email address for security contact is still on mirage.io, as ther…

### DIFF
--- a/data/wiki/security.md
+++ b/data/wiki/security.md
@@ -13,7 +13,7 @@ can be reported as usual on our [issue tracker][issues], but public forums are
 sometimes inappropriate for reporting security issues.
 
 If you think you've discovered a **security vulnerability**, the best way to
-inform us is to send us an email to **security [at] mirageos.org**.  One of the
+inform us is to send us an email to **security [at] mirage.io**.  One of the
 team will respond and we will take it from there.
 
 A OpenPGP key is [available from the keyservers](http://keys.mayfirst.org/pks/lookup?op=get&fingerprint=on&search=0x4A732D757C0EDA74), its fingerprint is `23B2 822C 89A9 EC73 C7DF  0748 4A73 2D75 7C0E DA74`.


### PR DESCRIPTION
…e's no mail server for mirageos.org

/cc @edwintorok 