### PR TITLE
Pin opam-repository to match base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN sudo apt-get update && sudo apt-get install autoconf automake -y --no-instal
 RUN mkdir -p /home/opam/www/mirage
 WORKDIR /home/opam/www
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 46f289cd
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 2dee2fe30df966714e056f8af164fe0ed7648a63
 RUN opam update
 RUN opam install 'mirage>=4.5.0'
 COPY --chown=opam:root mirage/config.ml /home/opam/www/mirage/


### PR DESCRIPTION
Pin opam-repository to the commit that matches the 4.14.2 base image. The current pin pulls in dependencies that cause the unikernel to crash on startup (exit 64).